### PR TITLE
Fixed gco tab completion, de-duped config from old dotfiles merge

### DIFF
--- a/git/aliases.zsh
+++ b/git/aliases.zsh
@@ -1,5 +1,5 @@
 # Use `hub` as our git wrapper:
-#   http://defunkt.github.com/hub/
+# http://defunkt.github.com/hub/
 hub_path=$(which hub)
 if (( $+commands[hub] ))
 then
@@ -14,6 +14,7 @@ alias gd='git diff'
 alias gc='git commit'
 alias gca='git commit -a'
 alias gco='git checkout'
+compdef _git gco='git-checkout'
 alias gb='git branch'
 alias gs='git status -sb' # upgrade your git if -sb breaks for you. it's fun.
 alias gst='gs' # Because I broke myself long ago.

--- a/zsh/config.zsh
+++ b/zsh/config.zsh
@@ -15,6 +15,7 @@ HISTFILE=~/.zsh_history
 HISTSIZE=10000
 SAVEHIST=10000
 
+setopt AUTOPUSHD
 setopt NO_BG_NICE # don't nice background tasks
 setopt NO_HUP
 setopt NO_LIST_BEEP
@@ -48,14 +49,3 @@ bindkey '^?' backward-delete-char
 
 # use incremental search
 bindkey '^R' history-incremental-search-backward
-
-# expand functions in the prompt
-setopt prompt_subst
-
-# ignore duplicate history entries
-setopt histignoredups
-
-setopt LOCAL_OPTIONS # allow functions to have local options
-setopt LOCAL_TRAPS # allow functions to have local traps
-
-setopt autopushd # Use pushd for all directory changing


### PR DESCRIPTION
After merging my old dotfiles in, I noticed that `gco ma<tab>` would not auto complete branch names (master in this example). It finally drove me crazy enough to track down. Looks like I needed a `compdef`. 
