### PR TITLE
Add Zig interop skill with verified FFI patterns for 0.15+

### DIFF
--- a/claude/config/settings.json
+++ b/claude/config/settings.json
@@ -215,6 +215,7 @@
     "gopls-lsp@claude-plugins-official": true,
     "typescript-lsp@claude-plugins-official": true,
     "ruby-lsp@claude-plugins-official": true,
+    "zls-lsp@zig-skills": true,
     "ast-grep@ast-grep-marketplace": true,
     "ruby-skills@ruby-skills": true,
     "gh-cli@trailofbits": true,
@@ -236,6 +237,12 @@
       "source": {
         "source": "github",
         "repo": "trailofbits/skills"
+      }
+    },
+    "zig-skills": {
+      "source": {
+        "source": "github",
+        "repo": "bnferguson/zig-skills"
       }
     }
   },

--- a/claude/config/skills/zig-interop/SKILL.md
+++ b/claude/config/skills/zig-interop/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: zig-interop
+description: >
+  This skill should be used when working on Zig FFI or cross-language
+  interoperability — wrapping C libraries, binding C++, exporting Zig
+  as C, bridging Zig with Rust/Swift/ObjC/Go/Ruby, configuring build.zig
+  for C compilation, or using comptime for FFI metaprogramming. Patterns
+  are extracted from production codebases (Bun, Ghostty, libxev,
+  TigerBeetle, Lightpanda). Targets Zig 0.14+. Complements
+  zig-programming (language fundamentals) and idiomatic-zig (style).
+---
+
+# Zig Interop Skill
+
+Patterns for bridging Zig with C, C++, Rust, Swift, and Objective-C, drawn from production projects that ship real FFI boundaries. This skill covers the mechanics of crossing language borders -- type mapping, memory ownership transfer, ABI compliance, build integration, and comptime code generation.
+
+## Table of Contents
+
+- [How to Use This Skill](#how-to-use-this-skill)
+- [Bundled Resources](#bundled-resources)
+- [@cImport Direct Binding](#cimport-direct-binding)
+- [C Shim Layer for C++](#c-shim-layer-for-cpp)
+- [Exporting Zig as a C Library](#exporting-zig-as-a-c-library)
+- [Cross-Language via C ABI](#cross-language-via-c-abi)
+- [Zig Build System C Compilation](#zig-build-system-c-compilation)
+- [Comptime Metaprogramming for FFI](#comptime-metaprogramming-for-ffi)
+- [Memory Ownership Across Boundaries](#memory-ownership-across-boundaries)
+- [Sources](#sources)
+
+## How to Use This Skill
+
+Pick the section that matches your task:
+
+- **Wrapping a C library** -- Start with [@cImport Direct Binding](#cimport-direct-binding) and the `cimport_wrapping.zig` example
+- **Binding C++ code** -- Read [C Shim Layer for C++](#c-shim-layer-for-cpp), then the shim pipeline in `cpp_shim_binding.zig`
+- **Exposing Zig to other languages** -- [Exporting Zig as a C Library](#exporting-zig-as-a-c-library) and `export_c_library.zig`
+- **Zig talking to Rust, Swift, ObjC, Go, or Ruby** -- [Cross-Language via C ABI](#cross-language-via-c-abi) and `cross_language_abi.zig`
+- **Building a multi-language client library** -- [Exporting Zig as a C Library](#exporting-zig-as-a-c-library) and `cross_language_consumers.zig`
+- **Compiling C sources with zig build** -- [Zig Build System C Compilation](#zig-build-system-c-compilation) and `build_c_sources.zig`
+- **Generating type-safe wrappers at comptime** -- [Comptime Metaprogramming for FFI](#comptime-metaprogramming-for-ffi) and `comptime_ffi_wrapper.zig`
+- **Ownership rules at FFI boundaries** -- [Memory Ownership Across Boundaries](#memory-ownership-across-boundaries) and `memory_ownership_boundary.zig`
+
+## Bundled Resources
+
+### References
+
+Load on demand when working on a specific interop pattern:
+
+| Reference | Description | Search hint |
+|-----------|-------------|-------------|
+| `references/cimport-and-type-mapping.md` | @cImport mechanics, Ghostty's c.zig pattern, Bun's pre-translation approach, opaque vs handle wrapping | `@cImport`, `translate-c` |
+| `references/cpp-shim-patterns.md` | Bun's codegen pipeline, `[[ZIG_EXPORT]]` annotations, ExternTraits, Errorable(T), flat C API alternatives | `C++ shim`, `extern "C"` |
+| `references/exporting-zig-as-c.md` | libxev's fixed-size byte arrays, Ghostty's CAPI struct, @fieldParentPtr smuggling, module.modulemap | `export fn`, `callconv` |
+| `references/cross-language-abi.md` | Zig-ObjC (zig-objc), Zig-Swift (module.modulemap), Zig-Rust, Zig-Go (cgo/runtime.Pinner), Zig-Ruby (zig.rb/RubyAllocator) | `ABI`, `Rust FFI`, `cgo`, `Ruby` |
+| `references/build-system-c-integration.md` | `addCSourceFiles`, `addTranslateC`, framework linking, allyourcodebase vendoring patterns, cross-compilation | `addCSourceFiles`, `linkSystemLibrary`, `addTranslateC` |
+| `references/comptime-ffi-metaprogramming.md` | zig-objc @Type synthesis, ziglua field walking, TigerBeetle foreign code gen, zig-gobject GIR pipeline | `comptime`, `@typeInfo`, `@Type` |
+
+### Examples
+
+Complete, annotated code demonstrating each pattern:
+
+| Example | Description |
+|---------|-------------|
+| `examples/cimport_wrapping.zig` | @cImport, type aliases, sentinel pointer conversion |
+| `examples/cpp_shim_binding.zig` | Zig side of a C++ shim: extern decls, init/deinit lifecycle |
+| `examples/export_c_library.zig` | Exporting Zig functions with opaque handles and error codes |
+| `examples/cross_language_abi.zig` | extern struct layout, callbacks, context pointer passing |
+| `examples/build_c_sources.zig` | build.zig template for compiling C alongside Zig |
+| `examples/comptime_ffi_wrapper.zig` | Comptime type reflection for type-safe C wrappers |
+| `examples/memory_ownership_boundary.zig` | Ownership transfer patterns across FFI boundaries |
+| `examples/cross_language_consumers.zig` | Comptime binding generator emitting Go/Rust/C types (TigerBeetle pattern) |
+
+## @cImport Direct Binding
+
+Zig's `@cImport` translates C headers at compile time, giving direct access to C types and functions without writing bindings by hand. Production projects take different approaches depending on header complexity:
+
+- **Dedicated c.zig files** -- Ghostty isolates each C library's `@cImport` into a per-package `c.zig` file (e.g., `pkg/freetype/c.zig`, `pkg/fontconfig/c.zig`). This prevents duplicate translation units and keeps import paths clean.
+- **Pre-translated bindings** -- Bun does NOT use `@cImport` for BoringSSL. Instead it ships a 19K-line pre-translated and manually enriched Zig file, giving tighter control over types and avoiding translate-c limitations.
+- **addTranslateC in build.zig** -- ziglua uses `addTranslateC` as a middle ground: build-time header translation without embedding `@cImport` in source.
+- **C ABI workaround files** -- When Zig's C ABI has platform-specific issues, Ghostty uses small ext.c files compiled alongside the Zig code as shims.
+
+See `references/cimport-and-type-mapping.md` for the full type mapping table and `examples/cimport_wrapping.zig` for a worked example wrapping a C library.
+
+## C Shim Layer for C++
+
+C++ cannot be imported directly. Production projects use different strategies depending on the C++ codebase's size and complexity:
+
+- **Codegen pipeline** -- Bun wraps JavaScriptCore through a three-layer system: C++ `bindings.cpp` files annotated with `[[ZIG_EXPORT(tag)]]`, a TypeScript code generator (`cppbind.ts`) that parses annotations and emits Zig bindings, and Zig opaque types that consume the generated declarations. Exception handling uses three tags: `nothrow`, `zero_is_throw`, `check_slow`.
+- **Flat C API alternative** -- Lightpanda does NOT wrap V8 C++ directly. It uses zig-v8-fork, which provides a pre-existing flat C API. When a maintained C API exists for your C++ dependency, prefer it over writing custom shims.
+- **ABI-compatible types** -- Bun's JSValue is `enum(i64)`, directly matching JSC's NaN-boxed EncodedJSValue. Errorable(T) is an ABI-safe tagged union for error propagation across the boundary. ExternTraits<T> in C++ define conversion rules (e.g., WTF::String uses `leakRef()` to transfer ownership).
+- **Opaque handle wrapping for STL types** -- zpp wraps `std::string` behind opaque `intptr_t` handles with three ownership modes (read-only, fixed write, growable write). C++ side uses `new`/`delete` behind `extern "C"` functions; Zig caches data pointer and length to avoid FFI calls on reads. Build requires `-fno-exceptions -fno-rtti` on the C++ side.
+- **Separate build systems** -- Bun's C++ is NOT compiled by build.zig. It uses a separate Ninja/TypeScript build system; Zig produces one .o file that links against the C++ artifacts.
+
+See `references/cpp-shim-patterns.md` and `examples/cpp_shim_binding.zig`.
+
+## Exporting Zig as a C Library
+
+Zig can produce shared or static libraries consumable by any C-compatible language. Production projects demonstrate two distinct approaches:
+
+- **Fixed-size byte array handles** -- libxev exposes opaque types as stack-allocatable C structs containing a fixed-size byte array (`uint8_t data[XEV_SIZEOF_LOOP - sizeof(XEV_ALIGN_T)]`). No heap allocation needed on the C side. Size validation tests prevent drift.
+- **CAPI struct pattern** -- Ghostty collects all `export fn` declarations into a single CAPI struct in `embedded.zig`. The C consumer receives one struct with all function pointers, rather than linking against individual symbols.
+- **Callback pointer smuggling** -- libxev extends its Completion struct with extra fields, then uses `@fieldParentPtr` to recover context inside callbacks -- avoiding a separate userdata pointer.
+- **Multi-language client pattern** -- TigerBeetle compiles one Zig core into platform-specific static libraries consumed by Go, Rust, Python, and other language clients through the C ABI. Comptime binding generators emit idiomatic types per target language. Gotcha: `u128` is passed as `[16]u8` because u128-by-value is broken across compilers.
+- **Swift consumption path** -- Ghostty exports through a hand-written `ghostty.h` header with a `module.modulemap`, allowing Swift to import the Zig library as `GhosttyKit`. XCFramework generation handles macOS/iOS targets.
+
+See `references/exporting-zig-as-c.md` and `examples/export_c_library.zig`.
+
+## Cross-Language via C ABI
+
+The C ABI is the lingua franca for cross-language calls. Production projects demonstrate several paths:
+
+- **Zig-ObjC via zig-objc** -- Ghostty uses mitchellh/zig-objc, NOT raw `objc_msgSend`. Pattern: `objc.getClass("NSFileManager").?.msgSend(objc.Object, objc.sel("defaultManager"), .{})`. Metal rendering is the heaviest ObjC consumer, with AutoreleasePool manually managed per frame.
+- **Zig-Swift via C API** -- Ghostty has no direct Zig-Swift bridge. Architecture: Zig export fn -> hand-written ghostty.h -> module.modulemap -> Swift imports as GhosttyKit. Swift passes userdata via `Unmanaged.passUnretained(self).toOpaque()`.
+- **Zig-Rust via extern "C"** -- Lightpanda bridges to html5ever: Rust exposes `extern "C"` functions, Zig declares matching extern prototypes. Callback-driven memory: Zig passes function pointers into Rust, Rust calls back for DOM mutations. No shared heap.
+- **Zig-Go via cgo** -- TigerBeetle's Go client links a pre-built Zig static library through cgo. Go objects accessed from Zig callback threads are pinned with `runtime.Pinner` for GC safety. Async bridge: Zig event loop fires a C completion callback that writes to a Go buffered channel. Achieves 94% of native Zig speed.
+- **Zig-Ruby via zig.rb** -- zig.rb implements `std.mem.Allocator` backed by Ruby's `xmalloc`/`xrealloc`/`xfree`, keeping Zig allocations visible to Ruby's GC. Comptime method binding validates signatures and generates per-arity C trampolines (0-15 args), avoiding varargs entirely. TypedDataClass wraps Zig structs as GC-tracked Ruby objects.
+- **Callback + userdata pattern** -- Ghostty's Options extern struct carries function pointers plus `?*anyopaque` userdata for each callback, letting the other language smuggle its own context through the C boundary.
+
+See `references/cross-language-abi.md` and `examples/cross_language_abi.zig`.
+
+## Zig Build System C Compilation
+
+`zig build` can compile C and C++ sources alongside Zig, replacing Make/CMake for many projects:
+
+- **Per-package build.zig** -- Ghostty isolates each C library in `pkg/<name>/` with its own `build.zig` and dedicated `c.zig` for `@cImport`. This keeps dependency boundaries clean and makes each library independently buildable.
+- **addTranslateC for headers** -- ziglua compiles upstream Lua C source via `addCSourceFiles` and uses `addTranslateC` for headers, supporting Lua 5.1-5.5, LuaJIT, and Luau from a single codebase via comptime version dispatch.
+- **Cross-compilation** -- Pass target triple; Zig's bundled libc headers handle sysroot concerns.
+- **Separate C++ build** -- Bun does NOT compile C++ through build.zig. When the C++ dependency has its own complex build system, link against pre-built artifacts rather than trying to replicate the build in Zig.
+
+See `references/build-system-c-integration.md` and `examples/build_c_sources.zig` (a build.zig template).
+
+## Comptime Metaprogramming for FFI
+
+Zig's comptime can generate type-safe wrappers from type information, eliminating boilerplate. But the approach depends on API surface size:
+
+- **Comptime function synthesis** -- zig-objc's core trick: `@Type(.{ .@"fn" = ... })` synthesizes `objc_msgSend` call signatures at comptime, selecting `_stret`/`_fpret` variants based on `builtin.target.cpu.arch` and return type. The MsgSend(T) mixin gives both Object and Class the same dispatch interface.
+- **Build-time code generation** -- vulkan-zig does NOT use comptime for the Vulkan API (too large). A generator executable runs during `zig build`, producing `vk.zig` with dispatch tables. Consumers use `inline for (std.meta.fields(Dispatch))` to load nullable function pointers from an opaque loader.
+- **Comptime version dispatch** -- ziglua's define.zig walks `@typeInfo(T).@"struct".fields` at comptime to generate Lua type definitions. A single codebase supports multiple Lua versions via `switch (lang)`.
+- **Comptime-generates-foreign-code** -- TigerBeetle's `rust_bindings.zig` and `go_bindings.zig` use Zig comptime to emit source code in other languages -- `#[repr(C)]` Rust structs and layout-compatible Go structs. The Zig build system runs the generator, and each language client consumes the output as checked-in generated code.
+- **Build-time XML-to-Zig pipeline** -- zig-gobject translates GIR XML into a complete Zig package with `build.zig`. Generated `extern fn` declarations are aliased to `pub const` (zero-cost). Comptime type hierarchy enables `isAssignableFrom()` that walks parent chains and interfaces at compile time, with `as()` for safe upcast and `cast()` returning `?*T` for downcast.
+- **Comptime bridge mapping** -- Lightpanda's bridge.zig uses `Builder(comptime T: type)` to map Zig types to JavaScript concepts at compile time.
+
+See `references/comptime-ffi-metaprogramming.md` and `examples/comptime_ffi_wrapper.zig`.
+
+## Memory Ownership Across Boundaries
+
+Memory ownership is the hardest part of FFI. Production projects use these strategies:
+
+- **Tagged pointer encoding** -- Bun's ZigString is an extern struct with UTF-16/Latin1 encoding packed into the high bits of the pointer, avoiding a separate encoding field.
+- **Callback-driven allocation** -- Lightpanda's Rust bridge passes function pointers into Rust; Rust calls back into Zig for DOM mutations. No shared heap means no cross-language allocator coordination.
+- **Custom allocator routing** -- Bun routes BoringSSL memory through mimalloc by exporting `OPENSSL_memory_alloc`/`OPENSSL_memory_free` hooks. The C library calls these instead of system malloc.
+- **Sentinel tracking** -- Ghostty's `ghostty_string_s` tracks a sentinel flag so the receiving side knows whether to scan for a null terminator or use a length field for deallocation.
+- **Ownership transfer via leakRef** -- Bun's ExternTraits<WTF::String> uses `leakRef()` to hand a reference-counted string across the boundary without the C++ side releasing it.
+
+See `examples/memory_ownership_boundary.zig` for a comprehensive example combining these patterns.
+
+## Sources
+
+### Tier 1 -- Production codebases with extensive FFI
+
+- **Bun** -- JavaScript runtime; C++ interop with JavaScriptCore via codegen pipeline, BoringSSL via pre-translated bindings, custom allocator routing through mimalloc
+- **Ghostty** -- Terminal emulator; Zig-ObjC via zig-objc, Zig-Swift via C API + module.modulemap, per-package C library isolation, CAPI struct pattern
+- **libxev** -- Cross-platform event loop; fixed-size byte array opaque handles, @fieldParentPtr callback smuggling, hand-written C header + pkg-config
+- **Lightpanda** -- Headless browser; flat C API via zig-v8-fork, Rust-Zig via callback-driven extern "C", comptime bridge mapping
+- **TigerBeetle** -- Financial transactions database; one Zig core with Go/Rust/Python/etc. clients via C ABI, comptime binding generators emit foreign-language source, u128-as-[16]u8 ABI workaround, runtime.Pinner for Go GC safety
+
+### Tier 2 -- Libraries and binding generators
+
+- **vulkan-zig** -- Build-time generated Vulkan bindings from XML spec, dispatch table pattern
+- **ziglua** -- Lua binding using addTranslateC + comptime version dispatch across Lua 5.1-5.5/LuaJIT/Luau
+- **zig-objc** -- Objective-C runtime bindings via comptime @Type function synthesis, architecture-aware dispatch
+- **zig-gobject** -- GIR XML-to-Zig pipeline with comptime-safe type hierarchy, zero-cost extern fn aliasing, typed signal connection
+- **zpp** -- C++ STL bridging via opaque handles; wraps std::string with three ownership modes, bidirectional data flow via function pointers
+- **zig.rb** -- Ruby extension framework; RubyAllocator (std.mem.Allocator backed by xmalloc), comptime per-arity trampoline generation, TypedDataClass for GC-tracked Zig structs
+- **allyourcodebase** -- Community collection of 115+ C library build.zig packages; vendoring patterns, config headers, platform dispatch without pkg-config

--- a/claude/config/skills/zig-interop/SKILL.md
+++ b/claude/config/skills/zig-interop/SKILL.md
@@ -6,7 +6,7 @@ description: >
   as C, bridging Zig with Rust/Swift/ObjC/Go/Ruby, configuring build.zig
   for C compilation, or using comptime for FFI metaprogramming. Patterns
   are extracted from production codebases (Bun, Ghostty, libxev,
-  TigerBeetle, Lightpanda). Targets Zig 0.14+. Complements
+  TigerBeetle, Lightpanda). Targets Zig 0.15+. Complements
   zig-programming (language fundamentals) and idiomatic-zig (style).
 ---
 

--- a/claude/config/skills/zig-interop/examples/build_c_sources.zig
+++ b/claude/config/skills/zig-interop/examples/build_c_sources.zig
@@ -1,0 +1,105 @@
+//! Build template for compiling C sources alongside Zig.
+//!
+//! Patterns from real projects:
+//! 1. System vs vendored build (Ghostty's pkg/ pattern).
+//! 2. addCSourceFiles with flags (ziglua).
+//! 3. addTranslateC for C header -> Zig module (ziglua).
+//! 4. Build-time code generation exe (vulkan-zig).
+//! 5. Framework linking + conditional OS checks (Ghostty).
+//! 6. Dual static/dynamic library output (libxev).
+
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+    const resolved = target.result;
+
+    // Pattern 1: system vs vendored, selected by build option
+    const use_system = b.option(bool, "system-freetype", "Use system FreeType") orelse false;
+
+    const exe = b.addExecutable(.{
+        .name = "myapp",
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    if (use_system) {
+        exe.linkSystemLibrary("freetype2");
+    } else {
+        // Pattern 2: addCSourceFiles with version-specific flags
+        exe.addCSourceFiles(.{
+            .files = &.{
+                "vendor/freetype/src/base/ftbase.c",
+                "vendor/freetype/src/base/ftsystem.c",
+                "vendor/freetype/src/truetype/truetype.c",
+            },
+            .flags = &.{ "-DFT2_BUILD_LIBRARY", "-std=c99", "-fno-sanitize=undefined" },
+        });
+        exe.addIncludePath(b.path("vendor/freetype/include"));
+    }
+
+    // Ghostty's ext.c workaround for constructs translate-c can't handle
+    exe.addCSourceFile(.{ .file = b.path("src/ext.c"), .flags = &.{"-std=c11"} });
+
+    // Pattern 3: addTranslateC — expose C types as `@import("lua")`
+    const translate_c = b.addTranslateC(.{
+        .root_source_file = b.path("vendor/lua/lua.h"),
+        .target = target,
+        .optimize = optimize,
+    });
+    translate_c.addIncludePath(b.path("vendor/lua"));
+    exe.root_module.addImport("lua", translate_c.createModule());
+
+    // Pattern 4: build-time code generation (vulkan-zig)
+    const generator = b.addExecutable(.{
+        .name = "generate-bindings",
+        .root_source_file = b.path("tools/gen_bindings.zig"),
+        .target = b.host,
+    });
+    const gen_step = b.addRunArtifact(generator);
+    gen_step.addArg("--spec");
+    gen_step.addFileArg(b.path("spec/api.xml"));
+    const gen_output = gen_step.addOutputFileArg("bindings.zig");
+    exe.root_module.addAnonymousImport("bindings", .{ .root_source_file = gen_output });
+
+    // Pattern 5: OS-conditional framework/library linking
+    exe.linkLibC();
+    switch (resolved.os.tag) {
+        .macos => {
+            exe.linkFramework("CoreText");
+            exe.linkFramework("CoreFoundation");
+        },
+        .linux => exe.linkSystemLibrary("fontconfig"),
+        else => {},
+    }
+    b.installArtifact(exe);
+
+    // Pattern 6: dual static/dynamic library (libxev)
+    inline for ([_]bool{ false, true }) |is_shared| {
+        const lib = if (is_shared) b.addSharedLibrary(.{
+            .name = "mylib",
+            .root_source_file = b.path("src/lib.zig"),
+            .target = target,
+            .optimize = optimize,
+        }) else b.addStaticLibrary(.{
+            .name = "mylib",
+            .root_source_file = b.path("src/lib.zig"),
+            .target = target,
+            .optimize = optimize,
+        });
+        lib.linkLibC();
+        b.installArtifact(lib);
+    }
+
+    // Tests
+    const tests = b.addTest(.{
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    tests.linkLibC();
+    const test_step = b.step("test", "Run unit tests");
+    test_step.dependOn(&b.addRunArtifact(tests).step);
+}

--- a/claude/config/skills/zig-interop/examples/build_c_sources.zig
+++ b/claude/config/skills/zig-interop/examples/build_c_sources.zig
@@ -1,4 +1,4 @@
-//! Build template for compiling C sources alongside Zig.
+//! Build template for compiling C sources alongside Zig (0.15+ API).
 //!
 //! Patterns from real projects:
 //! 1. System vs vendored build (Ghostty's pkg/ pattern).
@@ -7,29 +7,35 @@
 //! 4. Build-time code generation exe (vulkan-zig).
 //! 5. Framework linking + conditional OS checks (Ghostty).
 //! 6. Dual static/dynamic library output (libxev).
+//!
+//! 0.15 API changes from 0.14:
+//! - addExecutable/addTest/addLibrary take .root_module (not .root_source_file)
+//! - addCSourceFiles, addIncludePath, linkSystemLibrary, linkFramework are on Module
+//! - addStaticLibrary/addSharedLibrary merged into addLibrary with .linkage field
+//! - Module is created separately via b.createModule()
 
 const std = @import("std");
 
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
-    const resolved = target.result;
 
     // Pattern 1: system vs vendored, selected by build option
     const use_system = b.option(bool, "system-freetype", "Use system FreeType") orelse false;
 
-    const exe = b.addExecutable(.{
-        .name = "myapp",
+    const exe_mod = b.createModule(.{
         .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
+        .link_libc = true,
     });
 
     if (use_system) {
-        exe.linkSystemLibrary("freetype2");
+        exe_mod.linkSystemLibrary("freetype2", .{});
     } else {
         // Pattern 2: addCSourceFiles with version-specific flags
-        exe.addCSourceFiles(.{
+        exe_mod.addCSourceFiles(.{
+            .root = b.path(""),
             .files = &.{
                 "vendor/freetype/src/base/ftbase.c",
                 "vendor/freetype/src/base/ftsystem.c",
@@ -37,11 +43,11 @@ pub fn build(b: *std.Build) void {
             },
             .flags = &.{ "-DFT2_BUILD_LIBRARY", "-std=c99", "-fno-sanitize=undefined" },
         });
-        exe.addIncludePath(b.path("vendor/freetype/include"));
+        exe_mod.addIncludePath(b.path("vendor/freetype/include"));
     }
 
     // Ghostty's ext.c workaround for constructs translate-c can't handle
-    exe.addCSourceFile(.{ .file = b.path("src/ext.c"), .flags = &.{"-std=c11"} });
+    exe_mod.addCSourceFile(.{ .file = b.path("src/ext.c"), .flags = &.{"-std=c11"} });
 
     // Pattern 3: addTranslateC — expose C types as `@import("lua")`
     const translate_c = b.addTranslateC(.{
@@ -50,56 +56,60 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     translate_c.addIncludePath(b.path("vendor/lua"));
-    exe.root_module.addImport("lua", translate_c.createModule());
+    exe_mod.addImport("lua", translate_c.createModule());
 
     // Pattern 4: build-time code generation (vulkan-zig)
+    const gen_mod = b.createModule(.{
+        .root_source_file = b.path("tools/gen_bindings.zig"),
+        .target = b.graph.host,
+    });
     const generator = b.addExecutable(.{
         .name = "generate-bindings",
-        .root_source_file = b.path("tools/gen_bindings.zig"),
-        .target = b.host,
+        .root_module = gen_mod,
     });
     const gen_step = b.addRunArtifact(generator);
     gen_step.addArg("--spec");
     gen_step.addFileArg(b.path("spec/api.xml"));
     const gen_output = gen_step.addOutputFileArg("bindings.zig");
-    exe.root_module.addAnonymousImport("bindings", .{ .root_source_file = gen_output });
+    exe_mod.addAnonymousImport("bindings", .{ .root_source_file = gen_output });
 
     // Pattern 5: OS-conditional framework/library linking
-    exe.linkLibC();
-    switch (resolved.os.tag) {
+    switch (target.result.os.tag) {
         .macos => {
-            exe.linkFramework("CoreText");
-            exe.linkFramework("CoreFoundation");
+            exe_mod.linkFramework("CoreText", .{});
+            exe_mod.linkFramework("CoreFoundation", .{});
         },
-        .linux => exe.linkSystemLibrary("fontconfig"),
+        .linux => exe_mod.linkSystemLibrary("fontconfig", .{}),
         else => {},
     }
+    const exe = b.addExecutable(.{ .name = "myapp", .root_module = exe_mod });
     b.installArtifact(exe);
 
     // Pattern 6: dual static/dynamic library (libxev)
-    inline for ([_]bool{ false, true }) |is_shared| {
-        const lib = if (is_shared) b.addSharedLibrary(.{
-            .name = "mylib",
+    // In 0.15+, addStaticLibrary/addSharedLibrary merged into addLibrary
+    inline for ([_]std.builtin.LinkMode{ .static, .dynamic }) |linkage| {
+        const lib_mod = b.createModule(.{
             .root_source_file = b.path("src/lib.zig"),
             .target = target,
             .optimize = optimize,
-        }) else b.addStaticLibrary(.{
-            .name = "mylib",
-            .root_source_file = b.path("src/lib.zig"),
-            .target = target,
-            .optimize = optimize,
+            .link_libc = true,
         });
-        lib.linkLibC();
+        const lib = b.addLibrary(.{
+            .name = "mylib",
+            .root_module = lib_mod,
+            .linkage = linkage,
+        });
         b.installArtifact(lib);
     }
 
     // Tests
-    const tests = b.addTest(.{
+    const test_mod = b.createModule(.{
         .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
+        .link_libc = true,
     });
-    tests.linkLibC();
+    const tests = b.addTest(.{ .root_module = test_mod });
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&b.addRunArtifact(tests).step);
 }

--- a/claude/config/skills/zig-interop/examples/cimport_wrapping.zig
+++ b/claude/config/skills/zig-interop/examples/cimport_wrapping.zig
@@ -1,0 +1,86 @@
+//! @cImport wrapping patterns from Ghostty.
+//!
+//! 1. Dedicated c.zig module — isolates all C symbols to one @cImport block.
+//! 2. Opaque type wrapping (CoreText Font) — methods delegate to C functions.
+//! 3. Struct-with-handle (FreeType Face) — Zig struct owns the C handle.
+//!
+//! Alternative: Bun pre-translates complex C++ headers into Zig files,
+//! avoiding translate-c limitations with templates and overloaded functions.
+
+const std = @import("std");
+
+// --- Pattern 1: Dedicated @cImport module (the c.zig pattern) ---------------
+// In Ghostty this lives in its own file: `const c = @import("c.zig");`
+
+const c = @cImport({
+    @cInclude("freetype-zig.h");
+});
+
+const FT_Library = c.FT_Library;
+const FT_Face = c.FT_Face;
+const FT_Error = c.FT_Error;
+
+// --- Pattern 2: Opaque type wrapping (CoreText Font style) ------------------
+
+pub const Font = opaque {
+    extern fn CTFontCreateWithName(name: c.CFStringRef, size: f64, matrix: ?*const c.CGAffineTransform) ?*Font;
+    extern fn CTFontGetSize(font: *Font) f64;
+    extern fn CFRelease(cf: *anyopaque) void;
+
+    pub fn createWithName(name: c.CFStringRef, size: f64) ?*Font {
+        return CTFontCreateWithName(name, size, null);
+    }
+
+    pub fn getSize(self: *Font) f64 {
+        return CTFontGetSize(self);
+    }
+
+    pub fn release(self: *Font) void {
+        CFRelease(@ptrCast(self));
+    }
+};
+
+// --- Pattern 3: Struct-with-handle (FreeType Face style) --------------------
+// Owns the C handle, converts sentinel pointers at the boundary.
+
+pub const Face = struct {
+    handle: FT_Face,
+    library: FT_Library,
+
+    pub fn init(library: FT_Library, path: [:0]const u8) !Face {
+        var face: FT_Face = undefined;
+        const err = c.FT_New_Face(library, path.ptr, 0, &face);
+        if (err != 0) return error.FreetypeError;
+        return .{ .handle = face, .library = library };
+    }
+
+    pub fn deinit(self: Face) void {
+        _ = c.FT_Done_Face(self.handle);
+    }
+
+    pub fn setCharSize(self: Face, width: i32, height: i32, h_dpi: u32, v_dpi: u32) !void {
+        const err = c.FT_Set_Char_Size(self.handle, width, height, h_dpi, v_dpi);
+        if (err != 0) return error.FreetypeError;
+    }
+
+    /// Returns family name as a Zig slice. Valid until deinit.
+    pub fn familyName(self: Face) ?[]const u8 {
+        const raw: ?[*:0]const u8 = @ptrCast(self.handle.*.family_name);
+        return if (raw) |ptr| std.mem.span(ptr) else null;
+    }
+};
+
+// --- Tests ------------------------------------------------------------------
+
+test "opaque type pointer size matches anyopaque" {
+    try std.testing.expect(@sizeOf(*Font) == @sizeOf(*anyopaque));
+}
+
+test "sentinel-terminated path has null byte" {
+    const path: [:0]const u8 = "/usr/share/fonts/DejaVuSans.ttf";
+    try std.testing.expect(path[path.len] == 0);
+}
+
+test "c type aliases match expected sizes" {
+    try std.testing.expect(@sizeOf(FT_Error) == @sizeOf(c_int));
+}

--- a/claude/config/skills/zig-interop/examples/comptime_ffi_wrapper.zig
+++ b/claude/config/skills/zig-interop/examples/comptime_ffi_wrapper.zig
@@ -1,0 +1,130 @@
+//! Comptime FFI patterns from zig-objc, ziglua, and Lightpanda.
+//!
+//! 1. Function type synthesis via @Type (zig-objc msgSend).
+//! 2. @typeInfo struct field walking (ziglua's define.zig).
+//! 3. Comptime version dispatch (ziglua Lua 5.3/5.4/LuaJIT).
+//! 4. Comptime bridge builder (Lightpanda Zig-to-JS type mapping).
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+// --- Pattern 1: Function type synthesis (zig-objc's msgSend) ----------------
+pub fn ObjcSendFn(comptime Return: type, comptime ArgTypes: []const type) type {
+    var params: [ArgTypes.len + 2]std.builtin.Type.Fn.Param = undefined;
+    params[0] = .{ .is_generic = false, .is_noalias = false, .type = *anyopaque }; // id
+    params[1] = .{ .is_generic = false, .is_noalias = false, .type = *anyopaque }; // SEL
+    for (ArgTypes, 0..) |T, i| {
+        params[i + 2] = .{ .is_generic = false, .is_noalias = false, .type = T };
+    }
+    return @Type(.{ .@"fn" = .{
+        .calling_convention = .c,
+        .is_generic = false,
+        .is_var_args = false,
+        .return_type = Return,
+        .params = params[0 .. ArgTypes.len + 2],
+    } });
+}
+
+// x86_64: _stret for large structs, _fpret for floating point.
+// aarch64: base msgSend handles everything.
+pub fn msgSendVariant(comptime Return: type) [:0]const u8 {
+    if (builtin.cpu.arch == .x86_64) {
+        if (@typeInfo(Return) == .@"struct" and @sizeOf(Return) > 16) return "objc_msgSend_stret";
+        if (Return == f64 or Return == f80) return "objc_msgSend_fpret";
+    }
+    return "objc_msgSend";
+}
+
+// --- Pattern 2: @typeInfo struct field walking (ziglua) ---------------------
+pub fn FieldMeta(comptime T: type) type {
+    const fields = std.meta.fields(T);
+    return struct {
+        pub const count = fields.len;
+        pub const entries = blk: {
+            var result: [fields.len]struct { name: [:0]const u8, offset: usize, size: usize } = undefined;
+            for (fields, 0..) |f, i| {
+                result[i] = .{ .name = f.name, .offset = @offsetOf(T, f.name), .size = @sizeOf(f.type) };
+            }
+            break :blk result;
+        };
+    };
+}
+
+// --- Pattern 3: Comptime version dispatch (ziglua) --------------------------
+
+pub const LuaVersion = enum { lua53, lua54, luajit };
+
+pub fn LuaState(comptime version: LuaVersion) type {
+    return struct {
+        handle: *anyopaque,
+
+        pub fn pushInteger(_: @This(), _: i64) void {}
+
+        // lua_isinteger: 5.3+, not LuaJIT
+        pub const isInteger = switch (version) {
+            .lua53, .lua54 => struct { pub fn call(_: @This(), _: i32) bool { return true; } }.call,
+            .luajit => struct { pub fn call(_: @This(), _: i32) bool { return false; } }.call,
+        };
+
+        // lua_warning: 5.4+ only
+        pub usingnamespace if (version == .lua54) struct {
+            pub fn warning(_: @This(), _: [:0]const u8) void {}
+        } else struct {};
+    };
+}
+
+// --- Pattern 4: Comptime bridge builder (Lightpanda) ------------------------
+pub fn JsBridge(comptime T: type) type {
+    const fields = std.meta.fields(T);
+    return struct {
+        pub const property_count = fields.len;
+
+        pub fn getProperty(obj: *T, name: []const u8) ?i64 {
+            inline for (fields) |f| {
+                if (std.mem.eql(u8, name, f.name)) {
+                    const val = @field(obj, f.name);
+                    return switch (@typeInfo(f.type)) {
+                        .int => @intCast(val),
+                        .bool => if (val) @as(i64, 1) else 0,
+                        else => null,
+                    };
+                }
+            }
+            return null;
+        }
+    };
+}
+
+// --- Tests ------------------------------------------------------------------
+
+const TestPoint = extern struct { x: i32, y: i32, z: i32 };
+const Widget = struct { width: u32, height: u32, visible: bool };
+
+test "ObjcSendFn synthesizes correct signature" {
+    const info = @typeInfo(ObjcSendFn(void, &.{ u32, bool })).@"fn";
+    try std.testing.expectEqual(@as(usize, 4), info.params.len);
+    try std.testing.expect(info.calling_convention == .c);
+}
+
+test "msgSendVariant selects base for void return" {
+    try std.testing.expectEqualStrings("objc_msgSend", msgSendVariant(void));
+}
+
+test "FieldMeta walks struct fields" {
+    const meta = FieldMeta(TestPoint);
+    try std.testing.expectEqual(@as(usize, 3), meta.count);
+    try std.testing.expectEqualStrings("x", meta.entries[0].name);
+    try std.testing.expectEqual(@as(usize, 0), meta.entries[0].offset);
+}
+
+test "LuaVersion dispatch selects correct API" {
+    try std.testing.expect(@hasDecl(LuaState(.lua54), "warning"));
+    try std.testing.expect(!@hasDecl(LuaState(.luajit), "warning"));
+}
+
+test "JsBridge reflects struct properties" {
+    var w = Widget{ .width = 100, .height = 200, .visible = true };
+    const Bridge = JsBridge(Widget);
+    try std.testing.expectEqual(@as(i64, 100), Bridge.getProperty(&w, "width").?);
+    try std.testing.expect(Bridge.getProperty(&w, "nonexistent") == null);
+}

--- a/claude/config/skills/zig-interop/examples/comptime_ffi_wrapper.zig
+++ b/claude/config/skills/zig-interop/examples/comptime_ffi_wrapper.zig
@@ -7,6 +7,7 @@
 
 const std = @import("std");
 const builtin = @import("builtin");
+const CallingConvention = std.builtin.CallingConvention;
 
 // --- Pattern 1: Function type synthesis (zig-objc's msgSend) ----------------
 pub fn ObjcSendFn(comptime Return: type, comptime ArgTypes: []const type) type {
@@ -17,7 +18,7 @@ pub fn ObjcSendFn(comptime Return: type, comptime ArgTypes: []const type) type {
         params[i + 2] = .{ .is_generic = false, .is_noalias = false, .type = T };
     }
     return @Type(.{ .@"fn" = .{
-        .calling_convention = .c,
+        .calling_convention = CallingConvention.c,
         .is_generic = false,
         .is_var_args = false,
         .return_type = Return,
@@ -62,14 +63,20 @@ pub fn LuaState(comptime version: LuaVersion) type {
 
         // lua_isinteger: 5.3+, not LuaJIT
         pub const isInteger = switch (version) {
-            .lua53, .lua54 => struct { pub fn call(_: @This(), _: i32) bool { return true; } }.call,
-            .luajit => struct { pub fn call(_: @This(), _: i32) bool { return false; } }.call,
+            .lua53, .lua54 => struct {
+                pub fn call(_: @This(), _: i32) bool { return true; }
+            }.call,
+            .luajit => struct {
+                pub fn call(_: @This(), _: i32) bool { return false; }
+            }.call,
         };
 
-        // lua_warning: 5.4+ only
-        pub usingnamespace if (version == .lua54) struct {
-            pub fn warning(_: @This(), _: [:0]const u8) void {}
-        } else struct {};
+        // lua_warning: 5.4+ only.
+        // usingnamespace was removed in 0.14+; use a comptime bool flag instead.
+        pub const has_warning = version == .lua54;
+        pub fn warning(_: @This(), _: [:0]const u8) void {
+            comptime std.debug.assert(version == .lua54);
+        }
     };
 }
 
@@ -103,7 +110,7 @@ const Widget = struct { width: u32, height: u32, visible: bool };
 test "ObjcSendFn synthesizes correct signature" {
     const info = @typeInfo(ObjcSendFn(void, &.{ u32, bool })).@"fn";
     try std.testing.expectEqual(@as(usize, 4), info.params.len);
-    try std.testing.expect(info.calling_convention == .c);
+    try std.testing.expectEqual(CallingConvention.c, info.calling_convention);
 }
 
 test "msgSendVariant selects base for void return" {
@@ -118,8 +125,8 @@ test "FieldMeta walks struct fields" {
 }
 
 test "LuaVersion dispatch selects correct API" {
-    try std.testing.expect(@hasDecl(LuaState(.lua54), "warning"));
-    try std.testing.expect(!@hasDecl(LuaState(.luajit), "warning"));
+    try std.testing.expect(LuaState(.lua54).has_warning);
+    try std.testing.expect(LuaState(.luajit).has_warning == false);
 }
 
 test "JsBridge reflects struct properties" {

--- a/claude/config/skills/zig-interop/examples/cpp_shim_binding.zig
+++ b/claude/config/skills/zig-interop/examples/cpp_shim_binding.zig
@@ -1,0 +1,123 @@
+//! Zig-side patterns for binding C++ through a C shim, inspired by Bun.
+//!
+//! 1. Opaque types with extern fn methods (JSGlobalObject pattern).
+//! 2. Value type as enum(i64) — ABI-compatible with JSC's EncodedJSValue.
+//! 3. Errorable(T) — ABI-safe tagged union for cross-boundary error propagation.
+//! 4. Exception scope — init/check/deinit lifecycle.
+//!
+//! Alternative: Lightpanda uses a flat C API (V8 fork) instead of C++ shims.
+
+const std = @import("std");
+
+// --- Pattern 1: Opaque type with extern fn methods --------------------------
+
+pub const JSGlobalObject = opaque {
+    extern fn JSGlobalObject__throwOutOfMemoryError(this: *JSGlobalObject) void;
+    extern fn JSGlobalObject__createError(this: *JSGlobalObject, msg: JSValue) JSValue;
+
+    pub fn throwOutOfMemoryError(this: *JSGlobalObject) void {
+        JSGlobalObject__throwOutOfMemoryError(this);
+    }
+
+    pub fn createError(this: *JSGlobalObject, msg: JSValue) JSValue {
+        return JSGlobalObject__createError(this, msg);
+    }
+};
+
+// --- Pattern 2: Value type as enum(i64) (NaN-boxed JSValue) -----------------
+
+pub const JSValue = enum(i64) {
+    zero = 0,
+    undefined = 0x0a,
+    null_value = 0x02,
+    true_value = (0x06 | 0x01) + (1 << 49),
+    false_value = 0x06,
+    _,
+
+    pub fn isUndefined(this: JSValue) bool { return this == .undefined; }
+    pub fn isNull(this: JSValue) bool { return this == .null_value; }
+    pub fn fromRaw(raw: i64) JSValue { return @enumFromInt(raw); }
+    pub fn toRaw(this: JSValue) i64 { return @intFromEnum(this); }
+};
+
+// --- Pattern 3: Errorable(T) — ABI-safe tagged union -----------------------
+
+pub fn Errorable(comptime Type: type) type {
+    return extern struct {
+        result: Result,
+        success: bool,
+
+        pub const Result = extern union { value: Type, err: ZigError };
+
+        pub fn ok(value: Type) @This() {
+            return .{ .result = .{ .value = value }, .success = true };
+        }
+        pub fn failure(err: ZigError) @This() {
+            return .{ .result = .{ .err = err }, .success = false };
+        }
+        pub fn unwrap(self: @This()) !Type {
+            if (self.success) return self.result.value;
+            return error.JsError;
+        }
+    };
+}
+
+pub const ZigError = extern struct {
+    code: u32,
+    message: ExternString,
+};
+
+pub const ExternString = extern struct {
+    ptr: ?[*]const u8,
+    len: usize,
+
+    pub fn slice(self: ExternString) []const u8 {
+        const p = self.ptr orelse return &.{};
+        return p[0..self.len];
+    }
+};
+
+// --- Pattern 4: Exception scope lifecycle -----------------------------------
+
+pub const ExceptionScope = extern struct {
+    global: *JSGlobalObject,
+    exception: JSValue,
+
+    extern fn ExceptionScope__init(global: *JSGlobalObject) ExceptionScope;
+    extern fn ExceptionScope__deinit(scope: *ExceptionScope) void;
+
+    pub fn init(global: *JSGlobalObject) ExceptionScope {
+        return ExceptionScope__init(global);
+    }
+    pub fn deinit(self: *ExceptionScope) void {
+        ExceptionScope__deinit(self);
+    }
+    pub fn hasException(self: ExceptionScope) bool {
+        return !self.exception.isUndefined();
+    }
+};
+
+// --- Tests ------------------------------------------------------------------
+
+test "JSValue enum ABI matches i64" {
+    try std.testing.expectEqual(@sizeOf(i64), @sizeOf(JSValue));
+    try std.testing.expectEqual(@as(i64, 0x0a), @intFromEnum(JSValue.undefined));
+}
+
+test "JSValue round-trip through raw encoding" {
+    const val = JSValue.fromRaw(0xDEAD_BEEF);
+    try std.testing.expectEqual(@as(i64, 0xDEAD_BEEF), val.toRaw());
+}
+
+test "Errorable success and failure paths" {
+    const ok = Errorable(u32).ok(42);
+    try std.testing.expectEqual(@as(u32, 42), try ok.unwrap());
+
+    const fail = Errorable(u32).failure(.{ .code = 1, .message = .{ .ptr = null, .len = 0 } });
+    try std.testing.expectError(error.JsError, fail.unwrap());
+}
+
+test "ExternString empty slice on null ptr" {
+    const s = ExternString{ .ptr = null, .len = 0 };
+    try std.testing.expectEqual(@as(usize, 0), s.slice().len);
+}

--- a/claude/config/skills/zig-interop/examples/cross_language_abi.zig
+++ b/claude/config/skills/zig-interop/examples/cross_language_abi.zig
@@ -1,0 +1,115 @@
+//! Cross-language ABI patterns from Ghostty's C API layer.
+//!
+//! 1. Options extern struct — callconv(.c) function pointers + ?*anyopaque.
+//! 2. Platform variant — extern union for NSView/UIView/GtkWidget.
+//! 3. zig-objc msgSend — comptime function type synthesis via @Type.
+//! 4. Callback registration and context pointer round-trip.
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+// --- Pattern 1: Options extern struct (Ghostty's apprt config) --------------
+
+pub const SurfaceOptions = extern struct {
+    render_cb: ?*const fn (?*anyopaque) callconv(.c) void = null,
+    resize_cb: ?*const fn (u32, u32, ?*anyopaque) callconv(.c) void = null,
+    userdata: ?*anyopaque = null,
+    width: u32 = 800,
+    height: u32 = 600,
+    scale_factor: f64 = 1.0,
+};
+
+pub fn processFrame(opts: *const SurfaceOptions) void {
+    if (opts.render_cb) |cb| cb(opts.userdata);
+}
+
+// --- Pattern 2: Platform variant (extern union) -----------------------------
+
+pub const PlatformTag = enum(c_int) { macos = 0, ios = 1, gtk = 2 };
+
+pub const NativeView = extern struct {
+    tag: PlatformTag,
+    view: extern union {
+        ns_view: ?*anyopaque,
+        ui_view: ?*anyopaque,
+        gtk_widget: ?*anyopaque,
+    },
+};
+
+pub fn nativeTagForTarget() PlatformTag {
+    return switch (builtin.os.tag) {
+        .macos => .macos,
+        .ios => .ios,
+        .linux => .gtk,
+        else => .macos,
+    };
+}
+
+// --- Pattern 3: zig-objc msgSend type synthesis -----------------------------
+
+pub fn MsgSendFn(comptime Return: type, comptime Args: []const type) type {
+    var params: [Args.len + 2]std.builtin.Type.Fn.Param = undefined;
+    // Every objc_msgSend starts with (id, SEL)
+    params[0] = .{ .is_generic = false, .is_noalias = false, .type = ?*anyopaque };
+    params[1] = .{ .is_generic = false, .is_noalias = false, .type = ?*anyopaque };
+    for (Args, 0..) |A, i| {
+        params[i + 2] = .{ .is_generic = false, .is_noalias = false, .type = A };
+    }
+    return @Type(.{ .@"fn" = .{
+        .calling_convention = .c,
+        .is_generic = false,
+        .is_var_args = false,
+        .return_type = Return,
+        .params = params[0 .. Args.len + 2],
+    } });
+}
+
+// x86_64 uses _stret for large struct returns; aarch64 uses base msgSend.
+pub fn msgSendVariant(comptime Return: type) [:0]const u8 {
+    if (builtin.cpu.arch == .x86_64) {
+        if (@typeInfo(Return) == .@"struct" and @sizeOf(Return) > 16) return "objc_msgSend_stret";
+        if (Return == f64 or Return == f80) return "objc_msgSend_fpret";
+    }
+    return "objc_msgSend";
+}
+
+// --- Pattern 4: Callback registration with context round-trip ---------------
+
+pub const Renderer = struct {
+    frame_count: u64 = 0,
+
+    pub fn asOptions(self: *Renderer) SurfaceOptions {
+        return .{ .render_cb = &renderCb, .userdata = @ptrCast(self) };
+    }
+};
+
+fn renderCb(userdata: ?*anyopaque) callconv(.c) void {
+    const self: *Renderer = @ptrCast(@alignCast(userdata));
+    self.frame_count += 1;
+}
+
+// --- Tests ------------------------------------------------------------------
+
+test "callback round-trip through SurfaceOptions" {
+    var r = Renderer{};
+    const opts = r.asOptions();
+    processFrame(&opts);
+    processFrame(&opts);
+    try std.testing.expectEqual(@as(u64, 2), r.frame_count);
+}
+
+test "MsgSendFn synthesizes correct param count" {
+    const Fn = MsgSendFn(void, &.{u32});
+    const info = @typeInfo(Fn).@"fn";
+    try std.testing.expectEqual(@as(usize, 3), info.params.len);
+    try std.testing.expect(info.calling_convention == .c);
+}
+
+test "NativeView platform tag is valid" {
+    _ = @intFromEnum(nativeTagForTarget());
+}
+
+test "SurfaceOptions has C-compatible layout" {
+    try std.testing.expect(@sizeOf(SurfaceOptions) > 0);
+    try std.testing.expect(@alignOf(SurfaceOptions) <= 8);
+}

--- a/claude/config/skills/zig-interop/examples/cross_language_abi.zig
+++ b/claude/config/skills/zig-interop/examples/cross_language_abi.zig
@@ -7,6 +7,7 @@
 
 const std = @import("std");
 const builtin = @import("builtin");
+const CallingConvention = std.builtin.CallingConvention;
 
 // --- Pattern 1: Options extern struct (Ghostty's apprt config) --------------
 
@@ -56,7 +57,7 @@ pub fn MsgSendFn(comptime Return: type, comptime Args: []const type) type {
         params[i + 2] = .{ .is_generic = false, .is_noalias = false, .type = A };
     }
     return @Type(.{ .@"fn" = .{
-        .calling_convention = .c,
+        .calling_convention = CallingConvention.c,
         .is_generic = false,
         .is_var_args = false,
         .return_type = Return,
@@ -102,7 +103,7 @@ test "MsgSendFn synthesizes correct param count" {
     const Fn = MsgSendFn(void, &.{u32});
     const info = @typeInfo(Fn).@"fn";
     try std.testing.expectEqual(@as(usize, 3), info.params.len);
-    try std.testing.expect(info.calling_convention == .c);
+    try std.testing.expectEqual(CallingConvention.c, info.calling_convention);
 }
 
 test "NativeView platform tag is valid" {

--- a/claude/config/skills/zig-interop/examples/cross_language_consumers.zig
+++ b/claude/config/skills/zig-interop/examples/cross_language_consumers.zig
@@ -1,0 +1,186 @@
+//! Cross-language binding generation via comptime reflection.
+//!
+//! Demonstrates TigerBeetle's pattern of walking Zig type definitions at comptime
+//! to emit source code for foreign languages (C, Go, Rust). The Zig types are the
+//! single source of truth — bindings for each target language are derived, never
+//! hand-maintained.
+//!
+//! See: https://github.com/tigerbeetle/tigerbeetle (rust_bindings.zig, go_bindings.zig)
+
+const std = @import("std");
+
+/// Operation status codes returned by the storage engine.
+pub const Status = enum(u8) {
+    ok = 0,
+    exists = 1,
+    not_found = 2,
+    invalid = 3,
+};
+
+/// An account record with a 128-bit identifier.
+/// Uses extern layout for C ABI compatibility across all target languages.
+pub const Account = extern struct {
+    /// Unique account identifier. Represented as [16]u8 across the ABI boundary
+    /// because most calling conventions cannot pass u128 in registers.
+    id: u128,
+    /// Ledger this account belongs to.
+    ledger: u32,
+    /// Application-defined account type code.
+    code: u16,
+    /// Bitfield of boolean flags.
+    flags: u16,
+    /// Current balance in the account's native unit.
+    balance: u64,
+};
+
+/// Look up an account by its 128-bit id, passed as a byte array for ABI safety.
+export fn account_lookup(id_bytes: *const [16]u8) ?*const Account {
+    _ = id_bytes;
+    return null; // Stub -- real implementation indexes into storage.
+}
+
+/// Return the balance field from an account.
+export fn account_balance(account: *const Account) u64 {
+    return account.balance;
+}
+
+/// Maps Zig primitive types to their representation in a target language.
+fn resolve_foreign_type(comptime lang: Language, comptime T: type) []const u8 {
+    // u128 is not passable in registers on most ABIs -- project as a byte array.
+    // C uses a typedef (tb_uint128_t) because C arrays can't appear as struct
+    // field types in the `type name;` position -- TigerBeetle does the same.
+    if (T == u128) return switch (lang) {
+        .c => "tb_uint128_t",
+        .go => "[16]byte",
+        .rust => "[u8; 16]",
+    };
+    if (T == u64) return switch (lang) { .c => "uint64_t", .go => "uint64", .rust => "u64" };
+    if (T == u32) return switch (lang) { .c => "uint32_t", .go => "uint32", .rust => "u32" };
+    if (T == u16) return switch (lang) { .c => "uint16_t", .go => "uint16", .rust => "u16" };
+    if (T == u8) return switch (lang) { .c => "uint8_t", .go => "uint8", .rust => "u8" };
+    if (T == i64) return switch (lang) { .c => "int64_t", .go => "int64", .rust => "i64" };
+
+    if (@typeInfo(T) == .@"enum") {
+        return resolve_foreign_type(lang, @typeInfo(T).@"enum".tag_type);
+    }
+
+    @compileError("unmapped type: " ++ @typeName(T));
+}
+
+const Language = enum { c, go, rust };
+
+/// Emit a foreign struct definition by walking @typeInfo fields.
+fn emit_struct(comptime lang: Language, comptime T: type, writer: anytype) !void {
+    const name = @typeName(T);
+    switch (lang) {
+        .c => {
+            try writer.print("typedef struct {s} {{\n", .{name});
+            for (@typeInfo(T).@"struct".fields) |field| {
+                const ft = resolve_foreign_type(lang, field.type);
+                try writer.print("    {s} {s};\n", .{ ft, field.name });
+            }
+            try writer.print("}} {s};\n\n", .{name});
+        },
+        .go => {
+            try writer.print("type {s} struct {{\n", .{name});
+            for (@typeInfo(T).@"struct".fields) |field| {
+                const first: [1]u8 = .{std.ascii.toUpper(field.name[0])};
+                try writer.print("    {s}{s} {s}\n", .{ &first, field.name[1..], resolve_foreign_type(lang, field.type) });
+            }
+            try writer.writeAll("}\n\n");
+        },
+        .rust => {
+            try writer.writeAll("#[repr(C)]\n#[derive(Debug, Copy, Clone)]\n");
+            try writer.print("pub struct {s} {{\n", .{name});
+            for (@typeInfo(T).@"struct".fields) |field| {
+                try writer.print("    pub {s}: {s},\n", .{ field.name, resolve_foreign_type(lang, field.type) });
+            }
+            try writer.writeAll("}\n\n");
+        },
+    }
+}
+
+/// Emit a foreign enum definition by walking @typeInfo enum fields.
+fn emit_enum(comptime lang: Language, comptime T: type, writer: anytype) !void {
+    const info = @typeInfo(T).@"enum";
+    const name = @typeName(T);
+    const backing = resolve_foreign_type(lang, info.tag_type);
+
+    switch (lang) {
+        .c => {
+            try writer.print("typedef enum {s} {{\n", .{name});
+            for (info.fields) |field| {
+                try writer.print("    {s}_{s} = {d},\n", .{ name, field.name, field.value });
+            }
+            try writer.print("}} {s};\n\n", .{name});
+        },
+        .go => {
+            try writer.print("type {s} {s}\n\nconst (\n", .{ name, backing });
+            for (info.fields) |field| {
+                const first: [1]u8 = .{std.ascii.toUpper(field.name[0])};
+                try writer.print("    {s}{s}{s} {s} = {d}\n", .{ name, &first, field.name[1..], name, field.value });
+            }
+            try writer.writeAll(")\n\n");
+        },
+        .rust => {
+            try writer.writeAll("#[repr(" ++ backing ++ ")]\n#[derive(Debug, Copy, Clone, PartialEq, Eq)]\n");
+            try writer.print("pub enum {s} {{\n", .{name});
+            for (info.fields) |field| {
+                const first: [1]u8 = .{std.ascii.toUpper(field.name[0])};
+                try writer.print("    {s}{s} = {d},\n", .{ &first, field.name[1..], field.value });
+            }
+            try writer.writeAll("}\n\n");
+        },
+    }
+}
+
+fn generate(comptime lang: Language) []const u8 {
+    comptime {
+        var buf: [4096]u8 = undefined;
+        var stream = std.io.fixedBufferStream(&buf);
+        const writer = stream.writer();
+        emit_enum(lang, Status, writer) catch unreachable;
+        emit_struct(lang, Account, writer) catch unreachable;
+        const written = stream.getWritten();
+        // Copy to a comptime-persistent slice.
+        var result: [written.len]u8 = undefined;
+        @memcpy(&result, written);
+        return &result;
+    }
+}
+
+test "rust bindings contain repr(C) struct" {
+    const output = generate(.rust);
+    try std.testing.expect(std.mem.indexOf(u8, output, "#[repr(C)]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "pub struct Account") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "pub id: [u8; 16]") != null);
+}
+
+test "go bindings contain struct with exported fields" {
+    const output = generate(.go);
+    try std.testing.expect(std.mem.indexOf(u8, output, "type Account struct") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "Id [16]byte") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "Balance uint64") != null);
+}
+
+test "c bindings contain typedef struct" {
+    const output = generate(.c);
+    try std.testing.expect(std.mem.indexOf(u8, output, "typedef struct Account") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "tb_uint128_t id") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "uint64_t balance") != null);
+}
+
+test "enum generation includes all variants" {
+    const rust_output = generate(.rust);
+    try std.testing.expect(std.mem.indexOf(u8, rust_output, "Ok = 0") != null);
+    try std.testing.expect(std.mem.indexOf(u8, rust_output, "Not_found = 2") != null);
+
+    const go_output = generate(.go);
+    try std.testing.expect(std.mem.indexOf(u8, go_output, "StatusOk Status = 0") != null);
+}
+
+test "u128 maps to byte array in all languages" {
+    try std.testing.expectEqualStrings("[u8; 16]", resolve_foreign_type(.rust, u128));
+    try std.testing.expectEqualStrings("[16]byte", resolve_foreign_type(.go, u128));
+    try std.testing.expectEqualStrings("tb_uint128_t", resolve_foreign_type(.c, u128));
+}

--- a/claude/config/skills/zig-interop/examples/cross_language_consumers.zig
+++ b/claude/config/skills/zig-interop/examples/cross_language_consumers.zig
@@ -69,9 +69,15 @@ fn resolve_foreign_type(comptime lang: Language, comptime T: type) []const u8 {
 
 const Language = enum { c, go, rust };
 
+/// Extract the short name from a fully-qualified @typeName (e.g., "mod.Foo" -> "Foo").
+fn shortName(comptime full: [:0]const u8) [:0]const u8 {
+    const idx = comptime std.mem.lastIndexOfScalar(u8, full, '.') orelse return full;
+    return full[idx + 1 ..];
+}
+
 /// Emit a foreign struct definition by walking @typeInfo fields.
 fn emit_struct(comptime lang: Language, comptime T: type, writer: anytype) !void {
-    const name = @typeName(T);
+    const name = comptime shortName(@typeName(T));
     switch (lang) {
         .c => {
             try writer.print("typedef struct {s} {{\n", .{name});
@@ -103,7 +109,7 @@ fn emit_struct(comptime lang: Language, comptime T: type, writer: anytype) !void
 /// Emit a foreign enum definition by walking @typeInfo enum fields.
 fn emit_enum(comptime lang: Language, comptime T: type, writer: anytype) !void {
     const info = @typeInfo(T).@"enum";
-    const name = @typeName(T);
+    const name = comptime shortName(@typeName(T));
     const backing = resolve_foreign_type(lang, info.tag_type);
 
     switch (lang) {
@@ -134,19 +140,30 @@ fn emit_enum(comptime lang: Language, comptime T: type, writer: anytype) !void {
     }
 }
 
-fn generate(comptime lang: Language) []const u8 {
+fn generateLen(comptime lang: Language) usize {
     comptime {
         var buf: [4096]u8 = undefined;
         var stream = std.io.fixedBufferStream(&buf);
         const writer = stream.writer();
         emit_enum(lang, Status, writer) catch unreachable;
         emit_struct(lang, Account, writer) catch unreachable;
-        const written = stream.getWritten();
-        // Copy to a comptime-persistent slice.
-        var result: [written.len]u8 = undefined;
-        @memcpy(&result, written);
-        return &result;
+        return stream.getWritten().len;
     }
+}
+
+fn generate(comptime lang: Language) *const [generateLen(lang)]u8 {
+    const len = comptime generateLen(lang);
+    // Two-pass: first pass computes length, second copies by value via `.*`
+    // to avoid returning a reference to comptime-local memory.
+    const result = comptime blk: {
+        var buf: [4096]u8 = undefined;
+        var stream = std.io.fixedBufferStream(&buf);
+        const writer = stream.writer();
+        emit_enum(lang, Status, writer) catch unreachable;
+        emit_struct(lang, Account, writer) catch unreachable;
+        break :blk stream.getWritten()[0..len].*;
+    };
+    return &result;
 }
 
 test "rust bindings contain repr(C) struct" {

--- a/claude/config/skills/zig-interop/examples/export_c_library.zig
+++ b/claude/config/skills/zig-interop/examples/export_c_library.zig
@@ -1,0 +1,136 @@
+//! Exporting Zig as a C-consumable library, inspired by libxev and Ghostty.
+//!
+//! 1. Fixed-size byte array opaque handles (libxev) with size validation test.
+//! 2. CAPI struct containing all exports (Ghostty).
+//! 3. Callback with userdata (?*anyopaque) + callconv(.c) (Ghostty).
+//! 4. String type with ownership tracking (ghostty_string_s).
+//! 5. Error code translation via @intFromError (libxev).
+
+const std = @import("std");
+
+// --- The Zig implementation -------------------------------------------------
+
+pub const EventLoop = struct {
+    running: bool,
+    fd_count: u32,
+    tick: u64,
+    allocator: std.mem.Allocator,
+
+    pub fn init(allocator: std.mem.Allocator) EventLoop {
+        return .{ .running = false, .fd_count = 0, .tick = 0, .allocator = allocator };
+    }
+
+    pub fn addFd(self: *EventLoop) !void {
+        if (self.fd_count >= 1024) return error.TooManyFds;
+        self.fd_count += 1;
+    }
+
+    pub fn run(self: *EventLoop, cb: *const fn (?*anyopaque) callconv(.c) void, ud: ?*anyopaque) void {
+        self.running = true;
+        self.tick += 1;
+        cb(ud);
+        self.running = false;
+    }
+};
+
+// --- Pattern 1: Fixed-size byte array opaque handle (libxev) ----------------
+// C header: typedef struct { _Alignas(8) uint8_t data[XEV_LOOP_SIZE]; } xev_loop;
+
+const ALIGN = @alignOf(EventLoop);
+const HANDLE_SIZE = @sizeOf(EventLoop) + (ALIGN - @sizeOf(EventLoop) % ALIGN) % ALIGN;
+
+pub const LoopHandle = extern struct {
+    _pad: [ALIGN]u8 align(ALIGN),
+    data: [HANDLE_SIZE - ALIGN]u8,
+
+    fn fromZig(loop: *EventLoop) *LoopHandle { return @ptrCast(@alignCast(loop)); }
+    fn toZig(self: *LoopHandle) *EventLoop { return @ptrCast(@alignCast(self)); }
+};
+
+// --- Pattern 4: String with ownership tracking (ghostty_string_s) -----------
+
+pub const XString = extern struct {
+    ptr: ?[*]const u8,
+    len: usize,
+    owned: bool,
+
+    pub fn fromSlice(s: []const u8) XString { return .{ .ptr = s.ptr, .len = s.len, .owned = false }; }
+    pub fn fromOwned(s: []const u8) XString { return .{ .ptr = s.ptr, .len = s.len, .owned = true }; }
+    pub fn slice(self: XString) []const u8 {
+        const p = self.ptr orelse return &.{};
+        return p[0..self.len];
+    }
+};
+
+// --- Pattern 5: Error code via @intFromError --------------------------------
+
+fn errorToInt(err: anyerror) c_int {
+    return -@as(c_int, @intCast(@intFromError(err)));
+}
+
+// --- Pattern 2: CAPI struct (Ghostty) — all exports in one place -----------
+
+pub const CAPI = struct {
+    pub export fn xev_loop_init(h: *LoopHandle) c_int {
+        h.toZig().* = EventLoop.init(std.heap.c_allocator);
+        return 0;
+    }
+
+    pub export fn xev_loop_add_fd(h: *LoopHandle) c_int {
+        h.toZig().addFd() catch |err| return errorToInt(err);
+        return 0;
+    }
+
+    pub export fn xev_loop_run(h: *LoopHandle, cb: *const fn (?*anyopaque) callconv(.c) void, ud: ?*anyopaque) void {
+        h.toZig().run(cb, ud);
+    }
+
+    pub export fn xev_string_free(s: *XString) void {
+        if (!s.owned) return;
+        if (s.ptr) |p| std.heap.c_allocator.free(p[0..s.len]);
+        s.* = .{ .ptr = null, .len = 0, .owned = false };
+    }
+};
+
+// --- Tests ------------------------------------------------------------------
+
+test "LoopHandle size fits EventLoop" {
+    try std.testing.expect(@sizeOf(LoopHandle) >= @sizeOf(EventLoop));
+    try std.testing.expect(@alignOf(LoopHandle) >= @alignOf(EventLoop));
+}
+
+test "LoopHandle round-trip preserves state" {
+    var loop = EventLoop.init(std.testing.allocator);
+    loop.tick = 99;
+    try std.testing.expectEqual(@as(u64, 99), LoopHandle.fromZig(&loop).toZig().tick);
+}
+
+test "error code translation" {
+    try std.testing.expect(errorToInt(error.TooManyFds) < 0);
+}
+
+test "XString ownership tracking" {
+    const s = XString.fromSlice("hello");
+    try std.testing.expect(!s.owned);
+    try std.testing.expectEqualStrings("hello", s.slice());
+    try std.testing.expect(XString.fromOwned("x").owned);
+}
+
+test "CAPI init and add_fd" {
+    var h: LoopHandle = undefined;
+    try std.testing.expectEqual(@as(c_int, 0), CAPI.xev_loop_init(&h));
+    try std.testing.expectEqual(@as(c_int, 0), CAPI.xev_loop_add_fd(&h));
+}
+
+test "CAPI callback with userdata round-trip" {
+    var h: LoopHandle = undefined;
+    _ = CAPI.xev_loop_init(&h);
+    var called: bool = false;
+    CAPI.xev_loop_run(&h, &struct {
+        fn f(ctx: ?*anyopaque) callconv(.c) void {
+            const flag: *bool = @ptrCast(@alignCast(ctx));
+            flag.* = true;
+        }
+    }.f, @ptrCast(&called));
+    try std.testing.expect(called);
+}

--- a/claude/config/skills/zig-interop/examples/memory_ownership_boundary.zig
+++ b/claude/config/skills/zig-interop/examples/memory_ownership_boundary.zig
@@ -1,0 +1,128 @@
+//! Memory ownership at FFI boundaries, from Bun, Ghostty, and Lightpanda.
+//!
+//! 1. Tagged string (Bun's ZigString / Ghostty's ghostty_string_s).
+//! 2. Custom allocator hooks (Bun's BoringSSL mimalloc routing).
+//! 3. Callback-driven ownership (Lightpanda's Rust pattern: no shared heap).
+//! 4. leakRef ownership transfer (Bun's ExternTraits).
+//! 5. errdefer chains at FFI boundaries.
+
+const std = @import("std");
+
+// --- Pattern 1: Tagged string (ZigString / ghostty_string_s) ----------------
+
+pub const StringTag = enum(u2) { borrowed = 0, owned = 1, static = 2 };
+
+pub const TaggedString = extern struct {
+    _unsafe_ptr_do_not_use: [*]const u8,
+    len: usize,
+    // Bun packs the tag into high bits of the pointer; we use a field for clarity.
+    tag: StringTag,
+
+    pub fn borrowed(s: []const u8) TaggedString {
+        return .{ ._unsafe_ptr_do_not_use = s.ptr, .len = s.len, .tag = .borrowed };
+    }
+    pub fn owned(s: []const u8) TaggedString {
+        return .{ ._unsafe_ptr_do_not_use = s.ptr, .len = s.len, .tag = .owned };
+    }
+    pub fn slice(self: TaggedString) []const u8 {
+        return self._unsafe_ptr_do_not_use[0..self.len];
+    }
+    pub fn deinit(self: TaggedString, allocator: std.mem.Allocator) void {
+        if (self.tag == .owned) allocator.free(self._unsafe_ptr_do_not_use[0..self.len]);
+    }
+};
+
+// --- Pattern 2: Custom allocator hooks (BoringSSL mimalloc routing) ---------
+
+var ffi_allocator: std.mem.Allocator = std.heap.c_allocator;
+
+pub fn setGlobalAllocator(a: std.mem.Allocator) void { ffi_allocator = a; }
+
+// In real code these are `export fn` so the C library resolves them.
+fn cryptoMalloc(size: usize) callconv(.c) ?*anyopaque {
+    const buf = ffi_allocator.alignedAlloc(u8, 16, size) catch return null;
+    return @ptrCast(buf.ptr);
+}
+
+fn cryptoFree(ptr: ?*anyopaque, size: usize) callconv(.c) void {
+    if (ptr) |p| {
+        const aligned: [*]align(16) u8 = @ptrCast(@alignCast(p));
+        ffi_allocator.free(aligned[0..size]);
+    }
+}
+
+// --- Pattern 3: Callback-driven ownership (Lightpanda's Rust pattern) -------
+
+pub const RemoteAllocator = struct {
+    alloc_fn: *const fn (usize) callconv(.c) ?[*]u8,
+    free_fn: *const fn ([*]u8, usize) callconv(.c) void,
+
+    pub fn alloc(self: RemoteAllocator, size: usize) ![]u8 {
+        const ptr = self.alloc_fn(size) orelse return error.OutOfMemory;
+        return ptr[0..size];
+    }
+    pub fn free(self: RemoteAllocator, buf: []u8) void {
+        self.free_fn(buf.ptr, buf.len);
+    }
+};
+
+// --- Pattern 4: leakRef ownership transfer (Bun's ExternTraits) -------------
+
+pub fn RefCounted(comptime T: type) type {
+    return struct {
+        value: T,
+        allocator: std.mem.Allocator,
+        const Self = @This();
+
+        pub fn create(allocator: std.mem.Allocator, value: T) !*Self {
+            const self = try allocator.create(Self);
+            self.* = .{ .value = value, .allocator = allocator };
+            return self;
+        }
+        /// Transfer ownership to foreign code.
+        pub fn leakRef(self: *Self) *anyopaque { return @ptrCast(self); }
+        /// Reclaim a pointer previously handed out via leakRef.
+        pub fn releaseRef(raw: *anyopaque) void {
+            const self: *Self = @ptrCast(@alignCast(raw));
+            self.allocator.destroy(self);
+        }
+    };
+}
+
+// --- Pattern 5: errdefer chains at FFI boundaries ---------------------------
+
+pub fn initPipeline(allocator: std.mem.Allocator, remote: RemoteAllocator) !struct { local: []u8, remote_buf: []u8 } {
+    const local = try allocator.alloc(u8, 256);
+    errdefer allocator.free(local);
+    const remote_buf = try remote.alloc(128);
+    errdefer remote.free(remote_buf);
+    return .{ .local = local, .remote_buf = remote_buf };
+}
+
+// --- Tests ------------------------------------------------------------------
+
+test "TaggedString borrowed does not free" {
+    const s = TaggedString.borrowed("hello");
+    try std.testing.expectEqualStrings("hello", s.slice());
+    s.deinit(std.testing.allocator); // no-op
+}
+
+test "TaggedString owned frees on deinit" {
+    const buf = try std.testing.allocator.dupe(u8, "owned");
+    TaggedString.owned(buf).deinit(std.testing.allocator);
+}
+
+test "custom allocator hooks round-trip" {
+    const ptr = cryptoMalloc(64) orelse return error.TestFailed;
+    const bytes: [*]u8 = @ptrCast(ptr);
+    bytes[0] = 0xAB;
+    try std.testing.expectEqual(@as(u8, 0xAB), bytes[0]);
+    cryptoFree(ptr, 64);
+}
+
+test "leakRef and releaseRef ownership transfer" {
+    const Ref = RefCounted(u64);
+    const obj = try Ref.create(std.testing.allocator, 42);
+    try std.testing.expectEqual(@as(u64, 42), obj.value);
+    Ref.releaseRef(obj.leakRef());
+}

--- a/claude/config/skills/zig-interop/examples/memory_ownership_boundary.zig
+++ b/claude/config/skills/zig-interop/examples/memory_ownership_boundary.zig
@@ -10,7 +10,8 @@ const std = @import("std");
 
 // --- Pattern 1: Tagged string (ZigString / ghostty_string_s) ----------------
 
-pub const StringTag = enum(u2) { borrowed = 0, owned = 1, static = 2 };
+// Tag backing type must be extern-compatible (min 8-bit); u2 is not.
+pub const StringTag = enum(u8) { borrowed = 0, owned = 1, static_str = 2 };
 
 pub const TaggedString = extern struct {
     _unsafe_ptr_do_not_use: [*]const u8,
@@ -40,7 +41,8 @@ pub fn setGlobalAllocator(a: std.mem.Allocator) void { ffi_allocator = a; }
 
 // In real code these are `export fn` so the C library resolves them.
 fn cryptoMalloc(size: usize) callconv(.c) ?*anyopaque {
-    const buf = ffi_allocator.alignedAlloc(u8, 16, size) catch return null;
+    // In 0.15+, alignment is ?std.mem.Alignment (a log2 enum), not a raw integer.
+    const buf = ffi_allocator.alignedAlloc(u8, .@"4", size) catch return null; // .@"4" = 2^4 = 16
     return @ptrCast(buf.ptr);
 }
 

--- a/claude/config/skills/zig-interop/references/build-system-c-integration.md
+++ b/claude/config/skills/zig-interop/references/build-system-c-integration.md
@@ -1,0 +1,309 @@
+# Build System C Integration
+
+Zig's build system compiles C and C++ sources alongside Zig code, replacing Make or CMake for many projects. Real codebases demonstrate several distinct architectural patterns for organizing this.
+
+### Ghostty: pkg/<name>/build.zig Architecture
+
+Ghostty places each C library dependency in its own `pkg/<name>/` directory, each with its own `build.zig`. The top-level `build.zig` delegates to a `src/build/` module system that orchestrates everything.
+
+Each package's `build.zig` supports **system integration OR vendored builds**, selected at configure time:
+
+```zig
+// Ghostty's pattern for optional system library integration
+if (b.systemIntegrationOption("freetype", .{})) {
+    // Use system-installed freetype
+    step.linkSystemLibrary("freetype2");
+} else {
+    // Build freetype from vendored source in pkg/freetype/
+    const freetype = @import("pkg/freetype/build.zig");
+    freetype.link(step, target, optimize);
+}
+```
+
+This gives packagers (Homebrew, Nix, distros) the ability to link against system libraries while developers get reproducible vendored builds by default.
+
+---
+
+### ziglua: Building C from Source with addCSourceFiles
+
+ziglua compiles upstream Lua C source files directly, supporting Lua 5.1 through 5.5, LuaJIT, and Luau from a single codebase.
+
+```zig
+const lua_sources = &.{
+    "vendor/lua/lapi.c",
+    "vendor/lua/lcode.c",
+    "vendor/lua/ldebug.c",
+    "vendor/lua/ldo.c",
+    "vendor/lua/lfunc.c",
+    "vendor/lua/lgc.c",
+    // ... all Lua core sources
+};
+
+lib.addCSourceFiles(.{
+    .files = lua_sources,
+    .flags = &.{
+        "-std=c99",
+        "-DLUA_USE_POSIX",
+        "-fno-sanitize=undefined",
+    },
+});
+```
+
+**Separate flags per file set** when different sources need different options. Call `addCSourceFiles` multiple times rather than forcing one flag set on everything.
+
+#### addTranslateC for C Headers
+
+ziglua uses `addTranslateC` to convert Lua's C headers into a Zig module, making C types available as native Zig types without `@cImport`:
+
+```zig
+const translate_c = b.addTranslateC(.{
+    .root_source_file = b.path("vendor/lua/lua.h"),
+    .target = target,
+    .optimize = optimize,
+});
+translate_c.addIncludePath(b.path("vendor/lua"));
+const lua_module = translate_c.createModule();
+
+// Other modules can now import Lua types directly
+exe.root_module.addImport("lua", lua_module);
+```
+
+This approach produces a cached Zig file from the C header, enabling Zig-native access to all type definitions without runtime overhead.
+
+---
+
+### vulkan-zig: Build-Time Code Generation
+
+vulkan-zig takes a different approach — a generator executable runs during the build to produce Zig source from the Vulkan XML registry.
+
+```zig
+// build.zig
+const vk_gen = b.dependency("vulkan-zig", .{});
+const generator = vk_gen.artifact("generator");
+
+// Run the generator executable during build
+const generate_step = b.addRunArtifact(generator);
+generate_step.addFileArg(b.path("vk.xml"));
+const generated_source = generate_step.addOutputFileArg("vk.zig");
+
+// Use the generated file as a module
+exe.root_module.addImport("vulkan", b.createModule(.{
+    .root_source_file = generated_source,
+}));
+```
+
+The pattern: `b.addExecutable` for the generator, `b.addRunArtifact` to execute it, `addOutputFileArg` to capture the output, `b.createModule` to make it importable. The build system tracks dependencies automatically — regeneration happens only when `vk.xml` changes.
+
+The generated output includes dispatch tables with nullable function pointers for Vulkan's loader pattern. This is inspectable on disk, unlike comptime-generated types.
+
+---
+
+### libxev: Dual Static/Dynamic Build
+
+libxev produces both static and dynamic libraries from the same C API module, plus a hand-written header and generated pkg-config file:
+
+```zig
+const static_lib = b.addStaticLibrary(.{
+    .name = "xev",
+    .root_source_file = b.path("src/c_api.zig"),
+    .target = target,
+    .optimize = optimize,
+});
+
+const dynamic_lib = b.addSharedLibrary(.{
+    .name = "xev",
+    .root_source_file = b.path("src/c_api.zig"),
+    .target = target,
+    .optimize = optimize,
+});
+
+// Install the hand-written header
+b.installFile("include/xev.h", "include/xev.h");
+
+// Generate and install pkg-config file
+const pc = generatePkgConfig(b, "xev");
+b.installFile(pc, "lib/pkgconfig/xev.pc");
+
+b.installArtifact(static_lib);
+b.installArtifact(dynamic_lib);
+```
+
+This pattern enables C projects to consume the Zig library through standard tooling — `pkg-config --libs xev` works as expected.
+
+---
+
+### Bun: Split Build Architecture
+
+Bun does **not** compile C++ through `build.zig`. The C++ code (WebKit/JavaScriptCore integration) uses a separate Ninja build system. Zig's `build.zig` produces a single `.o` file for the Zig code only.
+
+For C system headers, Bun uses translate-c via a combined header:
+
+```zig
+// A single header that includes all needed system headers
+const translate_c = b.addTranslateC(.{
+    .root_source_file = b.path("src/c-headers-for-zig.h"),
+    .target = target,
+    .optimize = optimize,
+});
+```
+
+Generated C++ binding code is passed into the Zig build as module imports, not compiled by it. This split recognizes that some C++ codebases (WebKit) have build systems too complex to replicate in `build.zig`.
+
+---
+
+### Framework Linking and XCFramework Generation
+
+Ghostty links macOS and iOS frameworks conditionally:
+
+```zig
+const os = target.result.os.tag;
+if (os == .macos) {
+    lib.linkFramework("CoreFoundation");
+    lib.linkFramework("Metal");
+    lib.linkFramework("AppKit");
+    lib.linkFramework("IOKit");
+    lib.linkFramework("CoreGraphics");
+} else if (os == .ios) {
+    lib.linkFramework("UIKit");
+    lib.linkFramework("Metal");
+    lib.linkFramework("CoreGraphics");
+}
+```
+
+For distribution, Ghostty generates an **XCFramework** bundle that packages the library for both macOS and iOS targets. The build system produces platform-specific artifacts, then combines them with `xcodebuild -create-xcframework`.
+
+#### MetallibStep: Custom Build Steps
+
+Ghostty compiles Metal shaders through a custom build step that invokes `xcrun metal` and `xcrun metallib`:
+
+```zig
+// Custom step that compiles .metal → .air → .metallib
+const metallib = MetallibStep.create(b, .{
+    .name = "shaders",
+    .source = b.path("src/shaders/main.metal"),
+    .target = target,
+});
+lib.step.dependOn(&metallib.step);
+```
+
+Custom build steps extend `std.Build.Step` and can run arbitrary logic — Ghostty uses this pattern for any build artifact that Zig's built-in steps do not handle natively.
+
+---
+
+### addIncludePath vs addSystemIncludePath
+
+`addIncludePath` — for your own headers. The compiler emits warnings for issues in these files.
+
+`addSystemIncludePath` — for third-party headers. Suppresses warnings so vendor code does not pollute build output.
+
+```zig
+// Your headers — want warnings
+lib.addIncludePath(b.path("include"));
+
+// Vendored headers — suppress warnings
+lib.addSystemIncludePath(b.path("vendor/lua/include"));
+lib.addSystemIncludePath(b.path("vendor/freetype/include"));
+```
+
+Use `addSystemIncludePath` for anything you do not maintain.
+
+---
+
+### Cross-Compilation Considerations
+
+Zig bundles libc headers for many targets, making cross-compilation work without a separate toolchain:
+
+```zig
+const target = b.resolveTargetQuery(.{
+    .cpu_arch = .aarch64,
+    .os_tag = .linux,
+    .abi = .gnu,
+});
+
+exe.addCSourceFiles(.{
+    .files = &.{"vendor/sqlite3.c"},
+    .flags = &.{"-std=c99"},
+});
+exe.linkLibC();
+```
+
+C sources cross-compile alongside Zig code — Zig provides the compiler, headers, and linker for the target.
+
+When system integration packages are not available for the target, Ghostty's `systemIntegrationOption` pattern falls back to vendored source automatically. This makes cross-compilation the default case rather than a special one.
+
+For targets without bundled libc, specify a sysroot:
+
+```zig
+exe.addSysroot(.{ .cwd_relative = "/path/to/riscv64-sysroot" });
+```
+
+---
+
+### Memory Ownership
+
+Static linking produces one allocator heap — Zig and C code share the same `malloc`/`free`. Dynamic linking can produce **separate heaps** if each shared library links its own libc. Never `free` a pointer across a dynamic library boundary unless both sides provably share the same allocator.
+
+Bun routes BoringSSL's memory through mimalloc by exporting custom `OPENSSL_memory_alloc`, `OPENSSL_memory_free`, and `OPENSSL_memory_realloc` hooks. The free hook also **zeros memory before releasing it** — a security requirement for cryptographic allocations. This pattern works because static linking puts everything in the same address space.
+
+---
+
+### Build-From-Source Packages (allyourcodebase)
+
+The [allyourcodebase](https://github.com/allyourcodebase) organization maintains ~115 community packages, each wrapping a single C library with a `build.zig`. These packages demonstrate the minimal viable pattern for making C libraries available to the Zig ecosystem.
+
+**Two vendoring strategies** coexist across the repos:
+
+1. **Tarball dependency** — `build.zig.zon` declares a URL to the upstream release tarball. The Zig package manager fetches it at build time.
+2. **Committed sources** — the C source tree is checked into the repository directly, typically under a `vendor/` or `upstream/` directory.
+
+**None of these packages use `@cImport` internally.** They compile the C library from source using `addCSourceFiles` and produce a linkable artifact with installed headers. Downstream consumers link the library and `@cImport` the installed headers — the package itself does not bridge the C/Zig boundary.
+
+```zig
+// Downstream consumer pattern
+const zlib_dep = b.dependency("zlib", .{ .target = target, .optimize = optimize });
+exe.linkLibrary(zlib_dep.artifact("z"));
+exe.addIncludePath(zlib_dep.path("include"));
+```
+
+**Platform dispatch** uses `target.result.os.tag` switches rather than pkg-config. Since the libraries are built from source, there is no need to probe the host system for installed packages:
+
+```zig
+const os = target.result.os.tag;
+if (os == .linux) {
+    lib.addCSourceFile(.{ .file = b.path("src/platform_linux.c"), .flags = &.{} });
+} else if (os == .macos) {
+    lib.addCSourceFile(.{ .file = b.path("src/platform_darwin.c"), .flags = &.{} });
+} else if (os == .windows) {
+    lib.addCSourceFile(.{ .file = b.path("src/platform_win32.c"), .flags = &.{} });
+}
+```
+
+**Config headers** replace autoconf-style `config.h` generation. `b.addConfigHeader()` produces a header with `#define` values computed from the build configuration:
+
+```zig
+const config = b.addConfigHeader(.{
+    .style = .{ .autoconf = b.path("config.h.in") },
+});
+config.addValues(.{
+    .HAVE_UNISTD_H = target.result.os.tag != .windows,
+    .HAVE_STDINT_H = true,
+    .SIZEOF_LONG = @as(u64, target.result.ptrBitWidth() / 8),
+});
+lib.addConfigHeader(config);
+```
+
+The SDL package is the most complex example (~50KB `build.zig`), while zlib is among the simplest (54 lines). SDL also demonstrates **Zig version compatibility**: it checks `@hasDecl` for build API changes between Zig versions, allowing the same `build.zig` to work across multiple Zig releases:
+
+```zig
+// Zig version compat shim pattern from SDL
+const root_module = if (@hasDecl(std.Build, "createModule"))
+    lib.root_module
+else
+    lib.root_module_ptr.*;
+```
+
+The allyourcodebase pattern is complementary to Ghostty's `pkg/<name>/build.zig` approach. Ghostty vendors libraries inside its own repo with system-integration fallback; allyourcodebase publishes each library as a standalone Zig package. Both avoid pkg-config and build everything from source for cross-compilation.
+
+---
+
+See also: `references/cross-language-abi.md` for struct layout and linking across languages, `references/comptime-ffi-metaprogramming.md` for build-time vs comptime code generation tradeoffs.

--- a/claude/config/skills/zig-interop/references/cimport-and-type-mapping.md
+++ b/claude/config/skills/zig-interop/references/cimport-and-type-mapping.md
@@ -1,0 +1,248 @@
+# @cImport and Type Mapping
+
+Zig's `@cImport` translates C headers into Zig types at compile time. Under the hood it runs **translate-c**, the same tool available as `zig translate-c` on the command line. Production projects take different approaches depending on the complexity and reliability of the headers involved.
+
+---
+
+### Approaches to C Header Translation
+
+#### Dedicated c.zig Files (Ghostty)
+
+Ghostty isolates each C library's `@cImport` into a per-package `c.zig` file. Each package in `pkg/<name>/` has its own `c.zig` that contains exactly one `@cImport` block for that library.
+
+```zig
+// pkg/freetype/c.zig
+pub const c = @cImport({
+    @cInclude("freetype/freetype.h");
+    @cInclude("freetype/ftmodapi.h");
+});
+```
+
+This prevents duplicate type definitions (separate `@cImport` blocks produce separate translation units) and keeps import paths clean. Other Zig files import the namespace:
+
+```zig
+const c = @import("c.zig").c;
+```
+
+#### Pre-Translated Bindings (Bun)
+
+Bun does NOT use `@cImport` for BoringSSL. The 19K-line file is pre-translated from BoringSSL headers and then manually enriched with better type information, additional constants, and documentation. Reasons to pre-translate:
+
+- translate-c loses function-like macros
+- Manual enrichment can add Zig-native types where C headers use `int`
+- Build caching -- no translate-c invocation on every compile
+- Reproducibility -- the binding file is committed, not generated per-machine
+
+Use this approach when the C header surface is large, the library is stable, and translate-c drops important definitions.
+
+#### addTranslateC in build.zig (ziglua)
+
+ziglua uses `addTranslateC` as a middle ground. The build system translates headers at build time without embedding `@cImport` in source files:
+
+```zig
+// build.zig (simplified)
+const translated = b.addTranslateC(.{
+    .root_source_file = b.path("include/lua.h"),
+    .target = target,
+    .optimize = optimize,
+});
+lib.addModule("lua_h", translated.createModule());
+```
+
+This gives build-time control over include paths and defines while still auto-generating bindings. ziglua compiles upstream Lua C source via `addCSourceFiles` alongside this.
+
+---
+
+### Type Mapping Table
+
+| C Type | Zig Type | Notes |
+|--------|----------|-------|
+| `int` | `c_int` | Platform-dependent width |
+| `unsigned int` | `c_uint` | |
+| `long` | `c_long` | |
+| `size_t` | `usize` | |
+| `int8_t` | `i8` | Fixed-width types map directly |
+| `uint32_t` | `u32` | |
+| `float` | `f32` | |
+| `double` | `f64` | |
+| `char` | `u8` | Zig treats `char` as unsigned |
+| `_Bool` / `bool` | `bool` | |
+| `char *` | `[*c]u8` | C pointer -- nullable, arithmetic-capable |
+| `void *` | `*anyopaque` | Opaque pointer, must cast before use |
+| `T *` | `*c.T` or `[*c]c.T` | Single-item vs. many-item pointer |
+| `T[N]` | `[N]c.T` | Fixed-size arrays translate directly |
+| `struct S` | `c.S` or `c.struct_S` | Depends on typedef usage |
+| `enum E` | `c.E` or `c.enum_E` | Values become `c_int` by default |
+
+**Convert away from `[*c]` at the boundary** into proper Zig pointer types (`*T`, `[*]T`, `[]T`, or `?*T`).
+
+---
+
+### ABI-Compatible Type Design
+
+Production projects often define types that match C layouts exactly rather than relying on translate-c.
+
+#### Bun's JSValue: enum(i64)
+
+Bun represents JavaScript values as `enum(i64)` -- directly ABI-compatible with JSC's NaN-boxed `EncodedJSValue` (a 64-bit integer). No translation layer needed; the Zig enum IS the C type:
+
+```zig
+pub const JSValue = enum(i64) {
+    // Named sentinel values
+    zero = 0,
+    undefined = 0xa,
+    null_value = 0x2,
+    true_value = 0x7,
+    false_value = 0x6,
+    _,  // Non-exhaustive: any i64 is a valid JSValue
+};
+```
+
+This avoids struct wrapping overhead and matches the C++ side's `reinterpret_cast` patterns.
+
+#### Bun's ZigString: Tagged Pointer Encoding
+
+```zig
+pub const ZigString = extern struct {
+    ptr: [*]const u8,
+    len: usize,  // High bits encode UTF-16/Latin1 flag
+};
+```
+
+Encoding information is packed into the high bits of `len`, avoiding a separate field. The C++ side reads these bits to determine string encoding.
+
+---
+
+### Wrapping Opaque Types (Ghostty)
+
+Ghostty uses two distinct patterns for wrapping C library types, chosen based on whether Zig needs to access fields.
+
+#### Opaque Pattern (CoreText)
+
+When Zig never accesses internal fields, use the `opaque` type. Ghostty wraps CoreText types this way:
+
+```zig
+pub const Font = opaque {
+    pub fn createWithFontDescriptor(
+        desc: *const FontDescriptor,
+        size: f64,
+        matrix: ?*const [6]f64,
+    ) ?*Font {
+        return @ptrCast(@alignCast(
+            c.CTFontCreateWithFontDescriptor(
+                @ptrCast(desc),
+                size,
+                @ptrCast(matrix),
+            ),
+        ));
+    }
+
+    pub fn release(self: *Font) void {
+        c.CFRelease(@ptrCast(self));
+    }
+};
+```
+
+Methods are attached directly to the opaque type. The pointer never gets dereferenced on the Zig side -- it exists only to pass back into C functions.
+
+#### Struct-with-Handle Pattern (FreeType)
+
+When Zig needs to store the handle alongside other state:
+
+```zig
+pub const Face = struct {
+    handle: c.FT_Face,
+    library: *Library,
+
+    pub fn init(library: *Library, path: [*:0]const u8) !Face {
+        var face: c.FT_Face = undefined;
+        if (c.FT_New_Face(library.handle, path, 0, &face) != 0)
+            return error.FreeTypeError;
+        return .{ .handle = face, .library = library };
+    }
+
+    pub fn deinit(self: *Face) void {
+        _ = c.FT_Done_Face(self.handle);
+    }
+};
+```
+
+Choose this when the wrapper adds state (like back-references) or when multiple C handles need coordinated lifetime.
+
+---
+
+### C ABI Workaround Files
+
+When Zig's C ABI has platform-specific bugs, Ghostty uses small C files compiled alongside Zig as workarounds. These `ext.c` files contain trivial C functions that call the problematic APIs correctly:
+
+```c
+// ext.c -- workaround for Zig ABI issue with this specific call
+#include <CoreText/CoreText.h>
+
+CTFontRef ext_CTFontCreateWithFontDescriptor(
+    CTFontDescriptorRef desc, CGFloat size
+) {
+    return CTFontCreateWithFontDescriptor(desc, size, NULL);
+}
+```
+
+The Zig side declares the ext function as `extern` and calls it instead of the C library function directly. This is a pragmatic escape hatch -- file a Zig bug and use the workaround until it's fixed.
+
+---
+
+### Sentinel Pointers and Null-Terminated Strings
+
+C strings are `char *` with a null terminator. Zig represents this as `[*:0]const u8`. Convert at the boundary:
+
+```zig
+const c_str: [*:0]const u8 = c.get_name();
+const zig_slice: []const u8 = std.mem.span(c_str);
+
+// Runtime slices going to C need null-terminated copies
+const c_compatible = try allocator.dupeZ(u8, zig_slice);
+defer allocator.free(c_compatible);
+c.some_c_function(c_compatible.ptr);
+```
+
+`std.mem.span` scans for the sentinel -- O(n). Cache the result.
+
+---
+
+### Limitations
+
+#### Macros
+
+translate-c handles simple `#define` constants but cannot translate function-like macros. Rewrite as Zig `inline fn`. Check translate-c output to see what survived.
+
+#### Bitfields
+
+C bitfields have no stable ABI. Access through C helper functions or rewrite with packed structs:
+
+```zig
+const Flags = packed struct {
+    readable: bool,
+    writable: bool,
+    executable: bool,
+    _padding: u5 = 0,
+};
+```
+
+#### Inline Functions
+
+C `inline` functions sometimes translate, sometimes do not. Write Zig wrappers for any the code depends on.
+
+---
+
+### Memory Ownership
+
+When calling C functions that return pointers, determine who owns the allocation:
+
+- **C owns it** -- Do not free from Zig. Use `defer` to call the C cleanup function (Ghostty's `Font.release` calling `CFRelease`).
+- **Caller owns it** -- Call the library's free function or `std.c.free` if the C code used `malloc`.
+- **Borrowed pointer** -- Valid only for a limited scope. Copy if it needs to outlive that scope.
+
+Read the C library's documentation for every function that returns a pointer. When wrapping, document ownership in the Zig wrapper's doc comments.
+
+---
+
+See also: `references/cpp-shim-patterns.md` for wrapping C++ through a C shim layer, `references/exporting-zig-as-c.md` for the reverse direction.

--- a/claude/config/skills/zig-interop/references/comptime-ffi-metaprogramming.md
+++ b/claude/config/skills/zig-interop/references/comptime-ffi-metaprogramming.md
@@ -1,0 +1,334 @@
+# Comptime FFI Metaprogramming
+
+Zig's comptime evaluation turns type information into code at compile time — no external code generators, no macro preprocessors. For FFI, this means generating type-safe wrappers, dispatch logic, and binding tables from type definitions, with zero runtime cost.
+
+### zig-objc: Function Type Synthesis with @Type
+
+The canonical comptime FFI pattern. zig-objc synthesizes the correct `objc_msgSend` function pointer type at comptime based on the expected return type and argument types.
+
+The core technique uses `@Type(.{ .@"fn" = ... })` to construct a function type programmatically:
+
+```zig
+fn msgSendFnType(comptime ReturnType: type, comptime ArgTypes: []const type) type {
+    var params: [ArgTypes.len + 2]std.builtin.Type.Fn.Param = undefined;
+
+    // First two params are always (id, SEL)
+    params[0] = .{ .is_generic = false, .is_noalias = false, .type = objc.Id };
+    params[1] = .{ .is_generic = false, .is_noalias = false, .type = objc.SEL };
+
+    // Remaining params from the message signature
+    for (ArgTypes, 0..) |T, i| {
+        params[i + 2] = .{ .is_generic = false, .is_noalias = false, .type = T };
+    }
+
+    return @Type(.{
+        .@"fn" = .{
+            .calling_convention = .c,
+            .is_generic = false,
+            .is_var_args = false,
+            .return_type = ReturnType,
+            .params = &params,
+        },
+    });
+}
+```
+
+This replaces what would require runtime reflection or code generation in other languages. The compiler resolves the function pointer type entirely at compile time, producing a direct call with no dispatch overhead.
+
+---
+
+### zig-objc: Architecture-Aware Dispatch Selection
+
+ObjC message sends use different runtime functions depending on CPU architecture and return type. zig-objc selects the correct variant at comptime:
+
+```zig
+fn selectMsgSend(comptime ReturnType: type) *const anyopaque {
+    const arch = @import("builtin").cpu.arch;
+
+    if (arch == .x86_64) {
+        // x86_64 uses specialized variants
+        if (isLargeStruct(ReturnType)) return &objc_msgSend_stret;
+        if (ReturnType == f64) return &objc_msgSend_fpret;
+        return &objc_msgSend;
+    }
+
+    // aarch64 handles everything through base msgSend
+    return &objc_msgSend;
+}
+
+fn isLargeStruct(comptime T: type) bool {
+    const info = @typeInfo(T);
+    if (info != .@"struct") return false;
+    return @sizeOf(T) > 16; // Threshold for register passing
+}
+```
+
+The branch disappears entirely in the compiled output — on aarch64, only `objc_msgSend` exists in the binary. On x86_64, each call site uses the correct variant with no runtime check.
+
+---
+
+### zig-objc: Comptime Type Encoding for class_addMethod
+
+When registering Zig methods as ObjC method implementations, zig-objc generates the ObjC type encoding string at comptime from the Zig function signature:
+
+```zig
+fn encodeType(comptime T: type) [:0]const u8 {
+    if (T == objc.Id) return "@";
+    if (T == objc.SEL) return ":";
+    if (T == void) return "v";
+    if (T == bool) return "B";
+    if (T == f32) return "f";
+    if (T == f64) return "d";
+    if (T == c_int) return "i";
+    if (T == c_uint) return "I";
+    if (T == c_long) return "l";
+    // ...
+    @compileError("Unsupported type for ObjC encoding: " ++ @typeName(T));
+}
+
+fn methodTypeEncoding(comptime Fn: type) [:0]const u8 {
+    const info = @typeInfo(Fn).@"fn";
+    comptime var encoding: []const u8 = encodeType(info.return_type.?);
+    inline for (info.params) |param| {
+        encoding = encoding ++ encodeType(param.type.?);
+    }
+    return encoding ++ "\x00";
+}
+```
+
+The resulting encoding string is a compile-time constant embedded in the binary. `class_addMethod` receives it without any runtime string construction.
+
+---
+
+### ziglua: @typeInfo Struct Field Walking
+
+ziglua registers Zig types with the Lua runtime by walking struct and enum fields at comptime. The pattern uses `@typeInfo(T).@"struct".fields` to iterate fields and generate push/check logic for each:
+
+```zig
+fn pushStruct(comptime T: type, state: *lua.State, value: T) void {
+    const fields = @typeInfo(T).@"struct".fields;
+    state.createTable(0, fields.len);
+
+    inline for (fields) |field| {
+        state.pushString(field.name);
+        pushValue(field.type, state, @field(value, field.name));
+        state.setTable(-3);
+    }
+}
+
+fn pushValue(comptime T: type, state: *lua.State, value: T) void {
+    if (T == f64) { state.pushNumber(value); return; }
+    if (T == bool) { state.pushBoolean(value); return; }
+    if (T == []const u8) { state.pushString(value); return; }
+    if (@typeInfo(T) == .@"struct") { pushStruct(T, state, value); return; }
+    @compileError("Unsupported Lua type: " ++ @typeName(T));
+}
+```
+
+This generates specialized marshaling code for each struct type. A struct with three `f64` fields compiles to three `pushNumber` calls with no reflection overhead.
+
+---
+
+### ziglua: Comptime Version Dispatch
+
+ziglua supports Lua 5.1 through 5.5, LuaJIT, and Luau from a single codebase. Version differences are resolved at comptime using a `switch` on a comptime-known `lang` value:
+
+```zig
+pub fn getField(state: *State, index: i32, name: [:0]const u8) LuaType {
+    switch (lang) {
+        .lua51, .luajit => {
+            state.getField(index, name);
+            return state.typeOf(-1);
+        },
+        .lua52, .lua53, .lua54, .lua55 => {
+            return @enumFromInt(c.lua_getfield(state.state, index, name.ptr));
+        },
+        .luau => {
+            return @enumFromInt(c.lua_getfield(state.state, index, name.ptr));
+        },
+    }
+}
+```
+
+Because `lang` is comptime-known, the switch compiles to a single branch. The unused Lua version code is eliminated entirely. This is more maintainable than separate files per version — behavioral differences are visible inline.
+
+---
+
+### Lightpanda: Builder(comptime T: type) for V8 Mapping
+
+Lightpanda's JavaScript engine integration uses a comptime builder pattern to map Zig types to V8 concepts. Given a Zig type, `Builder` generates the V8 function templates, property descriptors, and accessor callbacks:
+
+```zig
+fn Builder(comptime T: type) type {
+    return struct {
+        pub fn build(isolate: *v8.Isolate) *v8.FunctionTemplate {
+            const tmpl = v8.FunctionTemplate.init(isolate, constructor);
+            const inst = tmpl.instanceTemplate();
+
+            const fields = @typeInfo(T).@"struct".fields;
+            inline for (fields) |field| {
+                if (isJSExposed(field)) {
+                    inst.setAccessor(
+                        field.name,
+                        makeGetter(T, field),
+                        makeSetter(T, field),
+                    );
+                }
+            }
+            return tmpl;
+        }
+
+        fn makeGetter(comptime Owner: type, comptime field: std.builtin.Type.StructField) v8.AccessorCallback {
+            return struct {
+                fn get(info: *const v8.PropertyCallbackInfo) void {
+                    const obj: *Owner = unwrapInternal(info.getThis());
+                    const value = @field(obj, field.name);
+                    info.getReturnValue().set(toV8Value(value));
+                }
+            }.get;
+        }
+    };
+}
+```
+
+Each Zig struct produces a unique `Builder` instantiation. The generated V8 template code is specialized per type — no generic property lookup at runtime.
+
+---
+
+### Comptime Code Generation Into Foreign Languages (TigerBeetle)
+
+TigerBeetle uses Zig comptime to walk its own type definitions and emit source code for other languages — Rust and Go — eliminating dual maintenance of shared types across language boundaries.
+
+`rust_bindings.zig` uses `resolve_rust_type()` to map Zig types to Rust equivalents, then `emit_struct()` and `emit_enum()` generate `#[repr(C)] #[derive(Debug, Copy, Clone)]` Rust structs, type aliases, and `extern "C"` blocks. `go_bindings.zig` follows the same pattern, emitting Go structs that match the C memory layout. The generated code lands in `src/tb_client.rs` and `bindings.go`.
+
+The conceptual pattern:
+
+```zig
+fn resolve_rust_type(comptime T: type) []const u8 {
+    if (T == u128) return "[u8; 16]"; // ABI workaround
+    if (T == u64) return "u64";
+    if (T == u32) return "u32";
+    if (T == u16) return "u16";
+    if (T == u8) return "u8";
+    if (T == i64) return "i64";
+    if (@typeInfo(T) == .@"enum") return @typeName(T);
+    @compileError("unmapped type: " ++ @typeName(T));
+}
+
+fn emit_struct(comptime T: type, writer: anytype) !void {
+    try writer.print("#[repr(C)]\n#[derive(Debug, Copy, Clone)]\npub struct {s} {{\n", .{@typeName(T)});
+    inline for (@typeInfo(T).@"struct".fields) |field| {
+        try writer.print("    pub {s}: {s},\n", .{ field.name, resolve_rust_type(field.type) });
+    }
+    try writer.print("}}\n\n", .{});
+}
+```
+
+The tradeoff: changing a Zig type requires re-running the Zig build step to regenerate foreign bindings. But this is far safer than manually keeping type definitions synchronized across three languages — the Zig types are the single source of truth, and the build fails if any type is unmapped.
+
+---
+
+### Build-Time Type Hierarchy Generation (zig-gobject)
+
+zig-gobject transforms GObject Introspection (GIR) XML into a complete Zig package through a multi-stage build pipeline: GIR XML → XSLT fixes (for upstream annotation errors) → `translate.zig` → Zig source. This is similar to vulkan-zig's XML-to-Zig pipeline, but the source is GIR introspection data rather than a graphics API spec, and the output includes an object-oriented type hierarchy.
+
+Generated `extern fn` declarations are aliased to `pub const` — zero-cost wrappers with better types than `@cImport` would produce:
+
+```zig
+// Generated: extern fn aliased to pub const for zero-cost better typing
+pub const setTitle = @extern(*const fn (*Self, [*:0]const u8) void, .{
+    .name = "gtk_window_set_title",
+});
+```
+
+The generator produces comptime type hierarchy functions from the GIR parent chain and interface data:
+
+- `isAssignableFrom()` walks the Parent chain and Implements list at compile time, enabling safe casting checks without runtime overhead
+- `as()` performs compile-time safe upcasts (child → parent), guaranteed valid by the type hierarchy
+- `cast()` performs runtime downcasts (parent → child), returning `?*T` to handle failure
+
+Signal, property, and virtual method definitions are also generated from introspection data:
+
+- `defineSignal()` — comptime signal definition with typed callback signatures
+- `defineProperty()` — comptime property definition with automatic ref/unref management
+- `defineClass()` — lazy type registration using `glib.Once` for thread safety (`initEnter`/`initLeave` pattern)
+- Virtual method vtable access: `gobject.ext.as(TypeName.Class, p_class).f_method_name`
+
+The contrast with vulkan-zig is instructive: both parse XML specs during the build step, but zig-gobject must also model an inheritance hierarchy and generate safe casting logic — a problem that does not exist in Vulkan's flat function-pointer model.
+
+---
+
+### When to Use Comptime vs Build-Step Generation
+
+#### Comptime (inline in source)
+
+Use when:
+- Transforming Zig type information (struct fields, function signatures, enums)
+- The "input" is Zig types already available at compile time
+- Output is used directly by Zig code in the same compilation unit
+
+Examples: zig-objc (function type synthesis), ziglua (type marshaling), Lightpanda (V8 template generation)
+
+#### Comptime Foreign Code Generation
+
+Use when:
+- The canonical type definitions live in Zig and must be projected to other languages
+- The generated output is source code in a foreign language (Rust, Go, C), not Zig
+- Type mappings are simple enough to express as comptime functions
+
+Example: TigerBeetle walks Zig struct/enum definitions at comptime and emits Rust and Go source files. The Zig types are the single source of truth — foreign bindings are derived, never hand-written.
+
+#### Build-Step Generation (in build.zig)
+
+Use when:
+- The input is an external file (XML, JSON, protocol spec)
+- Parsing requires complex logic that would exhaust the comptime evaluation budget
+- The generated output should be inspectable as a file on disk
+
+Examples: vulkan-zig parses the ~2MB Vulkan XML registry with a generator executable during the build step. zig-gobject processes GIR XML through XSLT and a translator to produce a typed Zig package with inheritance hierarchies.
+
+```zig
+const generate_step = b.addRunArtifact(generator);
+generate_step.addFileArg(b.path("vk.xml"));
+const generated = generate_step.addOutputFileArg("vk.zig");
+exe.root_module.addImport("vulkan", b.createModule(.{
+    .root_source_file = generated,
+}));
+```
+
+#### External Tooling (outside Zig entirely)
+
+Use when:
+- The source language has its own build toolchain (C++, TypeScript)
+- Binding generation requires analysis that Zig cannot perform
+
+Example: Bun uses `cppbind.ts` to generate C++ binding glue. The TypeScript tool produces C++ source files that are compiled by Ninja, not by `build.zig`. The generated code is then linked with the Zig `.o` file.
+
+---
+
+### Memory Ownership
+
+Comptime-generated wrappers must make ownership explicit in their signatures. Do not hide allocations inside generated code.
+
+When generating wrappers that cross language boundaries, propagate the allocator parameter or use caller-provided buffers:
+
+```zig
+// Good: caller controls the allocation
+fn generatedWrapper(allocator: Allocator, input: []const u8) ![:0]u8 {
+    return allocator.dupeZ(u8, input);
+}
+
+// Better: zero allocations, caller provides buffer
+fn generatedWrapperBuf(input: []const u8, buf: []u8) ![*:0]const u8 {
+    if (input.len >= buf.len) return error.BufferTooSmall;
+    @memcpy(buf[0..input.len], input);
+    buf[input.len] = 0;
+    return buf[0..input.len :0].ptr;
+}
+```
+
+For comptime type synthesis (zig-objc, Lightpanda Builder), ownership is inherent in the generated function signature — `objc_msgSend` returns values by the ObjC ownership convention, V8 accessor callbacks operate on GC-managed values. The comptime code does not introduce new ownership semantics; it preserves the target runtime's model.
+
+---
+
+See also: `references/cross-language-abi.md` for zig-objc in action (Ghostty's ObjC/Swift bridging), `references/build-system-c-integration.md` for build-step code generation details.

--- a/claude/config/skills/zig-interop/references/cpp-shim-patterns.md
+++ b/claude/config/skills/zig-interop/references/cpp-shim-patterns.md
@@ -1,0 +1,295 @@
+# C++ Shim Patterns
+
+Zig cannot import C++ directly. The language boundary requires a C-compatible interface. Production projects take fundamentally different approaches depending on the C++ codebase: Bun builds a codegen-driven shim pipeline for JavaScriptCore, while Lightpanda avoids custom shims entirely by using a pre-existing flat C API.
+
+---
+
+### Why Direct C++ Import Is Impossible
+
+C++ features with no C ABI equivalent: name mangling, templates, exceptions, RAII, overloading, vtables. The C ABI is the only stable binary interface shared between C++ compilers and Zig.
+
+---
+
+### Bun's Codegen Pipeline (JavaScriptCore)
+
+Bun wraps JSC through a three-layer system, with TypeScript code generation bridging C++ annotations to Zig declarations.
+
+#### Layer 1: Annotated C++ (bindings.cpp)
+
+C++ shim functions carry `[[ZIG_EXPORT(tag)]]` annotations that describe error handling behavior:
+
+```cpp
+// src/bun.js/bindings/bindings.cpp
+[[ZIG_EXPORT(nothrow)]]
+EncodedJSValue JSValue__jsNull() {
+    return JSC::JSValue::encode(JSC::jsNull());
+}
+
+[[ZIG_EXPORT(zero_is_throw)]]
+EncodedJSValue JSGlobalObject__createErrorInstance(
+    JSGlobalObject* global,
+    const ZigString* message
+) {
+    // Returns 0 (encoded null) on failure
+    auto scope = DECLARE_THROW_SCOPE(global->vm());
+    // ...
+}
+
+[[ZIG_EXPORT(check_slow)]]
+EncodedJSValue JSValue__call(
+    EncodedJSValue func,
+    JSGlobalObject* global,
+    const EncodedJSValue* args,
+    uint32_t arg_count
+) {
+    // Must check TopExceptionScope after return
+    // ...
+}
+```
+
+The three exception handling tags:
+- **nothrow** -- Function never throws. Zig calls it directly.
+- **zero_is_throw** -- Return value of 0 signals an exception. Zig checks the return.
+- **check_slow** -- Caller must inspect TopExceptionScope after the call returns.
+
+#### Layer 2: TypeScript Codegen (cppbind.ts)
+
+A TypeScript tool parses the `[[ZIG_EXPORT]]` annotations and generates Zig extern declarations. The generator produces opaque type definitions and function prototypes that match the C++ shim's ABI.
+
+#### Layer 3: Zig Consumer
+
+Zig code uses the generated declarations as opaque types. JSValue is `enum(i64)` -- directly ABI-compatible with JSC's NaN-boxed `EncodedJSValue`:
+
+```zig
+pub const JSValue = enum(i64) {
+    zero = 0,
+    undefined = 0xa,
+    _,
+};
+
+// Generated extern declarations (simplified)
+extern fn JSValue__jsNull() JSValue;
+extern fn JSValue__call(
+    func: JSValue,
+    global: *JSGlobalObject,
+    args: [*]const JSValue,
+    arg_count: u32,
+) JSValue;
+```
+
+---
+
+### ABI-Compatible Types Across the Boundary
+
+#### Errorable(T): Tagged Union for Error Propagation
+
+Bun defines an ABI-safe tagged union that crosses the C boundary without losing error information:
+
+```zig
+pub fn Errorable(comptime T: type) type {
+    return extern struct {
+        result: Result,
+        success: bool,
+
+        const Result = extern union {
+            value: T,
+            err: JSError,
+        };
+    };
+}
+```
+
+C++ returns `Errorable<JSValue>` from shim functions. Zig checks the `success` field and either unwraps the value or propagates the error.
+
+#### ExternTraits<T>: C++ Type Conversion Rules
+
+On the C++ side, `ExternTraits<T>` templates define how C++ types convert to C-compatible representations:
+
+```cpp
+template<>
+struct ExternTraits<WTF::String> {
+    static ZigString encode(const WTF::String& str) {
+        // leakRef() transfers ownership -- the Zig side
+        // is now responsible for releasing
+        auto impl = str.impl();
+        if (!impl) return ZigString{ nullptr, 0 };
+        impl->ref();  // Prevent C++ side from deallocating
+        return ZigString{
+            impl->characters8(),
+            impl->length() | (impl->is8Bit() ? LATIN1_FLAG : 0)
+        };
+    }
+};
+```
+
+`leakRef()` is the critical pattern: it increments the reference count so the C++ destructor does not free the backing memory. The Zig side must eventually release it.
+
+#### TopExceptionScope
+
+For `check_slow` tagged functions, Bun wraps exception checking:
+
+```cpp
+class TopExceptionScope {
+    JSGlobalObject* global;
+public:
+    TopExceptionScope(JSGlobalObject* g) : global(g) {}
+    bool hasException() const {
+        return global->vm().exception() != nullptr;
+    }
+    EncodedJSValue exception() const {
+        return JSC::JSValue::encode(global->vm().exception()->value());
+    }
+};
+```
+
+The Zig caller checks this scope after calling functions tagged `check_slow`.
+
+---
+
+### Flat C API Alternative (Lightpanda)
+
+Lightpanda does NOT wrap V8's C++ directly. It uses **zig-v8-fork**, which provides a flat C API over V8:
+
+```zig
+// Zig side -- calls into pre-existing C API, no custom shim
+extern fn v8__Isolate__New(params: *const CreateParams) *Isolate;
+extern fn v8__Isolate__Dispose(isolate: *Isolate) void;
+extern fn v8__Context__New(isolate: *Isolate) *Context;
+```
+
+When a maintained flat C API exists for your C++ dependency, prefer it. Writing and maintaining a custom shim for a large, actively-developed C++ project is a significant ongoing cost.
+
+Evaluate the tradeoff:
+- **Custom shim** -- Full control over the API surface, can expose exactly what you need, requires ongoing maintenance as the C++ API evolves
+- **Existing C API** -- Less control, may not expose everything, but maintenance burden shifts to the upstream project
+
+---
+
+### Build System Considerations
+
+#### Bun: Separate C++ Build
+
+Bun's C++ is NOT compiled by `build.zig`. The C++ side uses a separate Ninja/TypeScript build system. Zig produces one `.o` file that links against the C++ artifacts.
+
+This is appropriate when:
+- The C++ dependency has its own complex build (CMake, Ninja, Bazel)
+- C++ build flags are numerous and specialized
+- The C++ code is large enough that build.zig would struggle to replicate the configuration
+
+#### Simple Shims via build.zig
+
+For small, self-contained C++ shims (not Bun's case), compile through build.zig:
+
+```zig
+lib.addCSourceFiles(.{
+    .files = &.{"shim/bindings.cpp"},
+    .flags = &.{ "-std=c++17", "-fno-exceptions" },
+});
+lib.linkLibCpp();
+```
+
+Use `-fno-exceptions` when the shim catches all exceptions internally.
+
+---
+
+### RAII Bridging
+
+C++ constructors and destructors map to create/destroy functions in the shim. Zig's `defer` provides the cleanup guarantee:
+
+```zig
+pub fn processWithStream(path: [*:0]const u8) !void {
+    const stream = c.stream_create(path) orelse return error.StreamFailed;
+    defer c.stream_destroy(stream);
+
+    const buf = c.buffer_create(4096) orelse return error.BufferFailed;
+    defer c.buffer_destroy(buf);
+
+    const conn = c.connection_open(stream) orelse return error.ConnFailed;
+    errdefer c.connection_close(conn);
+
+    try doWork(conn, buf);
+    c.connection_close(conn);
+}
+```
+
+Every `create` must have a matching `destroy`. Wrap the pair in a Zig struct with `init`/`deinit`.
+
+---
+
+### Callback Bridging
+
+Pass Zig functions to C++ through function pointers with a context argument:
+
+```zig
+fn onEvent(ctx: ?*anyopaque, event_type: c_int, data: [*c]const u8) callconv(.c) void {
+    const self: *MyHandler = @ptrCast(@alignCast(ctx));
+    const event_data = if (data) |d| std.mem.span(d) else "";
+    self.handleEvent(event_type, event_data);
+}
+```
+
+`callconv(.c)` is required -- without it the function uses Zig's calling convention, which corrupts the stack when called from C/C++.
+
+---
+
+### Memory Ownership
+
+The shim creates a clear ownership boundary:
+
+- **C++ objects** -- Allocated with `new` in create, freed with `delete` in destroy. Zig holds a handle, never the raw object.
+- **Strings from C++ to Zig** -- Bun uses `leakRef()` on WTF::String to transfer ownership. The Zig side must eventually release.
+- **Strings from Zig to C++** -- The shim typically copies them (via `std::string` constructor). Zig retains ownership of its buffer.
+- **Tagged pointer encoding** -- Bun's ZigString packs encoding (UTF-16/Latin1) into high bits of the length field, avoiding a separate allocation for metadata.
+
+---
+
+### C++ STL Type Bridging (zpp)
+
+zpp wraps C++ STL types (primarily `std::string`) behind opaque `intptr_t` handles, providing Zig with safe access to C++ containers without exposing any C++ types across the boundary.
+
+#### Opaque Handle Pattern
+
+The C++ side allocates STL objects with `new` and returns the pointer as an `intptr_t`. Zig never sees the `std::string` layout — only the handle and accessor functions:
+
+```cpp
+// C++ side — extern "C" functions for std::string lifecycle
+extern "C" intptr_t stdstring_create(const char* data, uint32_t len) {
+    return reinterpret_cast<intptr_t>(new std::string(data, len));
+}
+
+extern "C" void stdstring_destroy(intptr_t handle) {
+    delete reinterpret_cast<std::string*>(handle);
+}
+
+extern "C" const char* stdstring_data(intptr_t handle) {
+    return reinterpret_cast<std::string*>(handle)->data();
+}
+
+extern "C" uint32_t stdstring_len(intptr_t handle) {
+    return reinterpret_cast<std::string*>(handle)->size();
+}
+```
+
+#### Three Ownership Modes
+
+zpp provides three wrapper types with different write semantics:
+
+- **StdString** -- Read-only access. Zig caches the data pointer and length after the first FFI call, avoiding repeated border crossings for subsequent reads.
+- **FixedStdString** -- Fixed-capacity write. Zig writes into a pre-allocated buffer; the C++ `std::string` does not reallocate.
+- **FlexStdString** -- Growable write. Zig can append data; the C++ side may reallocate, so the cached pointer is invalidated after writes.
+
+#### Read-Path Optimization
+
+Zig caches the data pointer and length returned by the accessor functions. Reads after the first call are pure Zig memory access with no FFI overhead. The cache is invalidated on any write operation.
+
+#### Bidirectional Data Flow
+
+C++ can call back into Zig through function pointers. zpp uses this for C++ code that needs to read from a Zig `ArrayList` — the Zig side exports accessor functions, and C++ calls them through stored function pointers.
+
+#### Build Requirements
+
+Compile the C++ shim with `-fno-exceptions -fno-rtti`. Exceptions cannot propagate across the `extern "C"` boundary, and RTTI is unnecessary when all types are opaque handles. These flags also reduce binary size.
+
+---
+
+See also: `references/cimport-and-type-mapping.md` for type mapping rules when importing the shim header, `references/exporting-zig-as-c.md` for the reverse direction.

--- a/claude/config/skills/zig-interop/references/cross-language-abi.md
+++ b/claude/config/skills/zig-interop/references/cross-language-abi.md
@@ -1,0 +1,304 @@
+# Cross-Language ABI
+
+The C ABI is the universal interop layer. When Zig talks to Objective-C, Swift, or Rust, both sides meet at C — never at each other's native ABI. Real projects demonstrate distinct patterns for each language pair.
+
+### Zig and Objective-C: zig-objc Runtime Bridging
+
+Ghostty uses mitchellh/zig-objc to call Objective-C without writing any .m files. The library wraps the ObjC runtime (`objc_msgSend`) with comptime type safety.
+
+#### Message Sends
+
+Retrieve a class, then send messages with return type and selector specified as comptime parameters:
+
+```zig
+const objc = @import("zig-objc");
+
+// Equivalent to: [NSProcessInfo processInfo]
+const info = objc.getClass("NSProcessInfo").?.msgSend(
+    objc.Object,
+    objc.sel("processInfo"),
+    .{},
+);
+```
+
+The `.msgSend` method synthesizes the correct function pointer type at comptime (see `references/comptime-ffi-metaprogramming.md` for the `@Type(.{ .@"fn" = ... })` technique underneath). It selects the right variant based on architecture:
+
+- **x86_64:** `objc_msgSend_stret` for large struct returns, `objc_msgSend_fpret` for `f64` returns
+- **aarch64:** always uses base `objc_msgSend` (ARM calling convention handles structs and floats in registers)
+
+#### ObjC Blocks
+
+zig-objc provides `objc.Block` for passing Zig functions as Objective-C block arguments. Ghostty uses this for completion handlers and notification observers where AppKit expects a block type.
+
+#### AutoreleasePool
+
+ObjC autorelease pools must be managed manually from Zig. Ghostty creates and drains a pool per frame to prevent unbounded memory growth from autoreleased ObjC objects:
+
+```zig
+const pool = objc.AutoreleasePool.init();
+defer pool.deinit();
+// All ObjC calls within this scope are covered
+```
+
+---
+
+### Zig and Swift: The C API Bridge
+
+Ghostty's Zig-to-Swift bridge follows a three-layer architecture:
+
+1. **Zig exports** functions with `export` and `callconv(.c)`
+2. **ghostty.h** declares the C prototypes
+3. **module.modulemap** wraps ghostty.h into a Clang module that Swift imports as `GhosttyKit`
+
+Swift code `import GhosttyKit` and calls the C functions directly — no `@_cdecl` needed on the Swift side for this direction.
+
+#### Options Struct with Callback Function Pointers
+
+Ghostty passes configuration from Swift to Zig via an `extern struct` containing `callconv(.c)` function pointers and a `?*anyopaque` userdata field:
+
+```zig
+pub const Options = extern struct {
+    // Callback function pointers with C calling convention
+    size_report: ?*const fn (u32, u32, ?*anyopaque) callconv(.c) void = null,
+    title_report: ?*const fn ([*:0]const u8, ?*anyopaque) callconv(.c) void = null,
+
+    // Opaque pointer for callback context
+    userdata: ?*anyopaque = null,
+};
+```
+
+Swift sets the userdata to `Unmanaged.passUnretained(self).toOpaque()`, then each callback casts it back:
+
+```swift
+// Swift side
+let ud = Unmanaged.passUnretained(self).toOpaque()
+options.userdata = ud
+options.size_report = { width, height, ctx in
+    let surface = Unmanaged<SurfaceView>.fromOpaque(ctx!).takeUnretainedValue()
+    surface.handleSizeReport(width, height)
+}
+```
+
+This pattern avoids ARC overhead on every callback invocation. Use `passUnretained` when the Swift object's lifetime is guaranteed to outlive the Zig usage.
+
+#### Platform View Passing
+
+Ghostty passes `NSView` (macOS) and `UIView` (iOS) through the C boundary as `?*anyopaque`. On the Zig side, convert to an `objc.Object` via `fromId()` to send messages:
+
+```zig
+fn attachToView(raw_view: ?*anyopaque) void {
+    const view = objc.Object.fromId(raw_view.?);
+    const layer = view.msgSend(objc.Object, objc.sel("layer"), .{});
+    // ...
+}
+```
+
+#### String Ownership
+
+Ghostty defines `ghostty_string_s` for ownership-tracked string passing across the boundary:
+
+```zig
+pub const String = extern struct {
+    ptr: [*]const u8,
+    len: usize,
+    sentinel: bool, // whether ptr is null-terminated
+};
+```
+
+Swift wraps this in `AllocatedString`, which calls `ghostty_string_free` in its `deinit`. The Zig side allocates; the Swift side frees through the provided function — never through Swift's own allocator.
+
+---
+
+### Zig and Rust: Matching extern "C" Declarations
+
+Lightpanda bridges Zig and Rust (html5ever) by declaring matching `extern "C"` signatures on both sides. There is no shared header — both sides manually maintain compatible declarations.
+
+Rust side:
+
+```rust
+#[no_mangle]
+pub extern "C" fn html5ever_parse(
+    input_ptr: *const u8,
+    input_len: usize,
+    callback: extern "C" fn(*const Node, *mut c_void),
+    userdata: *mut c_void,
+) -> i32 {
+    // Parse HTML, invoke callback for each DOM node
+}
+```
+
+Zig side:
+
+```zig
+extern "C" fn html5ever_parse(
+    input_ptr: [*]const u8,
+    input_len: usize,
+    callback: *const fn (*const Node, ?*anyopaque) callconv(.c) void,
+    userdata: ?*anyopaque,
+) c_int;
+```
+
+#### Callback-Driven Memory Model
+
+Lightpanda uses a **shared-nothing** approach: Zig passes function pointers into Rust for DOM mutations. Rust never allocates on Zig's heap or vice versa. DOM nodes are built on the Zig side inside the callback — Rust only passes data needed to construct them.
+
+This eliminates the need for a shared allocator or cross-language free functions. Each side manages its own memory exclusively.
+
+---
+
+### Zig and Go via cgo
+
+TigerBeetle's Go client links a pre-built Zig static library through cgo. The architecture: Zig core compiles to a platform-specific `.a` file, and the Go client imports it with `#cgo LDFLAGS`.
+
+#### GC Safety with runtime.Pinner
+
+Go's garbage collector can relocate objects. Any Go object whose address is visible to Zig (e.g., passed as a callback context or written into a shared buffer) must be pinned:
+
+```go
+var pinner runtime.Pinner
+pinner.Pin(&request)
+defer pinner.Unpin()
+// Now safe to pass &request through cgo into Zig
+```
+
+Without pinning, the GC may move the object while Zig holds a pointer to it, causing silent corruption.
+
+#### Async Bridge: Zig Event Loop to Go Channel
+
+TigerBeetle's Zig core runs its own event loop. Completions flow back to Go through a C callback that writes to a buffered Go channel:
+
+1. Go submits a request through cgo, passing a completion context
+2. Zig event loop processes the request asynchronously
+3. Zig fires a C completion callback with the result
+4. The C callback writes to a Go `chan` — unblocking the waiting goroutine
+
+This bridges Zig's async model to Go's channel-based concurrency without either side adopting the other's primitives.
+
+#### Comptime-Generated Layout-Compatible Structs
+
+TigerBeetle's `go_bindings.zig` uses Zig comptime to emit Go struct definitions that are byte-for-byte compatible with the C structs. The Go client deserializes responses with zero copying — the raw bytes from Zig map directly onto Go struct fields.
+
+#### Performance
+
+The Go client achieves 94% of native Zig throughput. The overhead comes from cgo call cost and channel synchronization, not from data copying.
+
+#### Memory Model
+
+Each side uses its own allocator. Zig uses `std.heap.c_allocator`; Go uses its runtime allocator with `runtime.Pinner` for any objects that cross the boundary. No cross-language allocator coordination.
+
+---
+
+### Zig and Ruby
+
+#### zig.rb: RubyAllocator
+
+zig.rb implements `std.mem.Allocator` backed by Ruby's memory functions (`xmalloc`, `xrealloc`, `xfree`). Zig allocations made through this allocator are visible to Ruby's GC for memory pressure tracking:
+
+```zig
+// Conceptual — zig.rb provides this as a ready-made allocator
+const ruby_allocator = RubyAllocator.init();
+var list = std.ArrayList(u8).init(ruby_allocator);
+```
+
+#### Comptime Method Binding
+
+zig.rb validates method signatures at comptime and generates per-arity C trampolines (0 through 15 arguments). This avoids Ruby's varargs API entirely — each arity gets a dedicated `extern "C"` function with the exact parameter count Ruby expects.
+
+#### TypedDataClass
+
+`TypedDataClass` wraps a Zig struct as a Ruby typed data object with GC marking support. Ruby's GC can mark, sweep, and compact the wrapper while the Zig struct's memory is managed through the RubyAllocator.
+
+#### Alternative: Direct C Extension (katafrakt/zig-ruby)
+
+For simpler cases, katafrakt/zig-ruby uses `@cVaStart`/`@cVaArg` to work directly with Ruby's varargs C extension API. Build integration: `extconf.rb` generates a Makefile that invokes `zig build` with `RUBY_HDRDIR` and `RUBY_LIBDIR` environment variables pointing to the Ruby installation's headers and libraries.
+
+---
+
+### extern struct: Layout Guarantees
+
+Use `extern struct` when a struct crosses a language boundary. Zig's default struct layout is undefined — the compiler reorders fields. An `extern struct` guarantees C-compatible layout: fields in declaration order with platform-standard alignment and padding.
+
+```zig
+const ImageBuffer = extern struct {
+    data: [*]u8,
+    width: u32,
+    height: u32,
+    stride: u32,
+    format: PixelFormat,
+};
+```
+
+Place larger-aligned fields first to minimize padding. A `u8` followed by a `u64` wastes 7 bytes; reverse them and it wastes none.
+
+---
+
+### extern union for Platform Variants
+
+Use `extern union` paired with an enum tag for values that differ by platform:
+
+```zig
+const PlatformView = extern union {
+    ns_view: ?*anyopaque,  // NSView* on macOS
+    ui_view: ?*anyopaque,  // UIView* on iOS
+    hwnd: ?*anyopaque,     // HWND on Windows
+};
+
+const ViewHandle = extern struct {
+    platform: enum(c_int) { macos = 0, ios = 1, windows = 2 },
+    view: PlatformView,
+};
+```
+
+Unlike Zig's native tagged unions, `extern union` has no built-in discriminant. Always send the tag — the other language must check it before accessing a field.
+
+---
+
+### Enum Representation
+
+Specify the integer backing type when enums cross ABI boundaries:
+
+```zig
+const PixelFormat = enum(c_int) {
+    rgba8 = 0,
+    bgra8 = 1,
+    rgb565 = 2,
+    _,  // Allow unknown values from C
+};
+```
+
+The `_` catch-all is critical. C code may pass values outside your known set. Without it, Zig triggers safety-checked undefined behavior on an unknown value.
+
+---
+
+### Memory Ownership
+
+#### Shared-Nothing (Lightpanda Pattern)
+
+Each language manages its own heap. Data crosses the boundary through callbacks or caller-provided buffers. No cross-language free functions needed.
+
+#### Ownership-Tracked Strings (Ghostty Pattern)
+
+One side allocates, the other side receives a struct with the data and a free function. Ghostty's `ghostty_string_s` + `ghostty_string_free` ensures Swift always calls the correct deallocator.
+
+#### GC-Aware Patterns (Go and Ruby)
+
+When the other language has a garbage collector, additional coordination is required. Go's `runtime.Pinner` pins objects that Zig holds pointers to, preventing the GC from relocating them. Ruby's zig.rb takes the opposite approach: a custom `std.mem.Allocator` backed by `xmalloc`/`xfree` ensures all Zig allocations are visible to Ruby's GC for memory pressure tracking.
+
+#### Caller-Provided Buffers
+
+The safest default — caller allocates, callee fills:
+
+```zig
+extern "C" fn render_frame(
+    engine: *anyopaque,
+    output_buf: [*]u8,
+    buf_len: usize,
+    out_written: *usize,
+) c_int;
+```
+
+No ambiguity about who frees what. Prefer this when buffer sizes are predictable.
+
+---
+
+See also: `references/exporting-zig-as-c.md` for multi-language export patterns, `references/build-system-c-integration.md` for linking multi-language artifacts, `references/comptime-ffi-metaprogramming.md` for zig-objc's comptime type synthesis.

--- a/claude/config/skills/zig-interop/references/exporting-zig-as-c.md
+++ b/claude/config/skills/zig-interop/references/exporting-zig-as-c.md
@@ -1,0 +1,288 @@
+# Exporting Zig as C
+
+Zig can produce shared and static libraries with a C-compatible API. libxev and Ghostty demonstrate two distinct approaches: libxev uses fixed-size byte array handles for stack-allocatable opaque types, while Ghostty collects all exports into a CAPI struct with a hand-written header chain for Swift consumption.
+
+---
+
+### libxev: Fixed-Size Byte Array Handles
+
+libxev's C header exposes opaque types as fixed-size structs containing a byte array. C consumers can stack-allocate these without knowing the internal layout:
+
+```c
+// xev.h (hand-written)
+#define XEV_SIZEOF_LOOP 512
+#define XEV_ALIGN_T size_t
+
+typedef struct {
+    XEV_ALIGN_T _pad;
+    uint8_t data[XEV_SIZEOF_LOOP - sizeof(XEV_ALIGN_T)];
+} xev_loop;
+
+typedef struct {
+    XEV_ALIGN_T _pad;
+    uint8_t data[XEV_SIZEOF_COMPLETION - sizeof(XEV_ALIGN_T)];
+} xev_completion;
+```
+
+The Zig side casts between the byte array and the real type:
+
+```zig
+export fn xev_loop_create() xev_loop {
+    var result: xev_loop = undefined;
+    const loop = Loop.init() catch return zeroed_loop;
+    @as(*Loop, @ptrCast(@alignCast(&result.data))) .* = loop;
+    return result;
+}
+
+export fn xev_loop_run(loop: *xev_loop) c_int {
+    const real: *Loop = @ptrCast(@alignCast(&loop.data));
+    real.run() catch |err| return @intFromError(err);
+    return 0;
+}
+```
+
+This avoids heap allocation on the C side entirely. The consumer declares `xev_loop loop;` on the stack.
+
+#### Size Validation Tests
+
+libxev uses compile-time and runtime tests to prevent the byte array sizes from drifting behind the real struct:
+
+```zig
+test "opaque type sizes" {
+    // If Loop grows beyond 512 bytes, this test fails --
+    // update XEV_SIZEOF_LOOP in the C header
+    try testing.expect(@sizeOf(xev.Loop) <= 512);
+    try testing.expect(@sizeOf(xev.Completion) <= 256);
+}
+```
+
+Run these tests in CI. A size increase without a header update produces silent memory corruption.
+
+---
+
+### libxev: Callback Pointer Smuggling via @fieldParentPtr
+
+libxev extends its Completion struct with an extra field rather than using a separate userdata pointer. The callback recovers context via `@fieldParentPtr`:
+
+```zig
+const MyCompletion = struct {
+    // Embed the library's completion as the first field
+    completion: xev.Completion,
+    // Extra application state follows
+    buffer: []u8,
+    handler: *Handler,
+};
+
+fn callback(completion: *xev.Completion, result: xev.Result) void {
+    // Recover the containing struct from the embedded field
+    const my: *MyCompletion = @fieldParentPtr("completion", completion);
+    my.handler.onComplete(my.buffer, result);
+}
+```
+
+This is more efficient than a separate `void* userdata` -- one pointer instead of two, and the context is always the right type.
+
+---
+
+### libxev: Error Code Translation
+
+Zig error unions cannot cross the C boundary. libxev converts them to integer error codes:
+
+```zig
+export fn xev_loop_run(loop: *xev_loop) c_int {
+    const real: *Loop = @ptrCast(@alignCast(&loop.data));
+    real.run() catch |err| return @intFromError(err);
+    return 0;  // Success
+}
+```
+
+`@intFromError(err)` produces a stable integer for each error value. Pair with a strerror-style function:
+
+```zig
+export fn xev_strerror(code: c_int) [*:0]const u8 {
+    const err = @errorFromInt(code) catch return "unknown error";
+    return @errorName(err);
+}
+```
+
+Convention: return 0 for success, positive integers for errors (matching `@intFromError` output).
+
+---
+
+### libxev: Build Output
+
+libxev builds both static and dynamic libraries, installs a hand-written header, and generates a pkg-config file:
+
+```zig
+// build.zig (simplified)
+const static = b.addStaticLibrary(.{ .name = "xev", ... });
+const shared = b.addSharedLibrary(.{ .name = "xev", ... });
+
+b.installArtifact(static);
+b.installArtifact(shared);
+static.installHeader(b.path("include/xev.h"), "xev.h");
+
+// pkg-config generation
+const pc = b.addInstallFile(
+    generatePkgConfig(b, static),
+    "lib/pkgconfig/libxev.pc",
+);
+b.getInstallStep().dependOn(&pc.step);
+```
+
+---
+
+### Ghostty: CAPI Struct Pattern
+
+Ghostty collects all exported function declarations into a single CAPI struct in `embedded.zig`. The C consumer receives one struct containing all function pointers rather than linking against individual symbols:
+
+```zig
+// src/apprt/embedded.zig (simplified)
+pub const CAPI = struct {
+    // App lifecycle
+    app_new: *const fn (*const Options) ?*App,
+    app_free: *const fn (*App) void,
+
+    // Surface management
+    surface_new: *const fn (*App, *const SurfaceOptions) ?*Surface,
+    surface_free: *const fn (*Surface) void,
+    surface_set_size: *const fn (*Surface, u32, u32) void,
+
+    // Input handling
+    surface_key_event: *const fn (*Surface, *const KeyEvent) bool,
+    surface_mouse_event: *const fn (*Surface, *const MouseEvent) bool,
+
+    // ... all other exports
+};
+```
+
+This pattern is useful when the consuming language (Swift, in Ghostty's case) benefits from receiving a single initialization point rather than resolving dozens of individual symbols.
+
+---
+
+### Ghostty: Options with Callback Function Pointers
+
+Ghostty passes configuration and callbacks through extern structs with function pointers and `?*anyopaque` userdata:
+
+```zig
+pub const Options = extern struct {
+    // Callbacks the host must implement
+    write_callback: ?*const fn (?*anyopaque, [*]const u8, usize) void,
+    size_callback: ?*const fn (?*anyopaque, *u32, *u32) void,
+    focus_callback: ?*const fn (?*anyopaque) void,
+
+    // Context pointer passed to every callback
+    userdata: ?*anyopaque,
+
+    // Configuration values
+    initial_width: u32,
+    initial_height: u32,
+};
+```
+
+The Swift side fills this in with `Unmanaged.passUnretained(self).toOpaque()` for userdata:
+
+```swift
+var opts = ghostty_options_s()
+opts.userdata = Unmanaged.passUnretained(self).toOpaque()
+opts.write_callback = { ctx, data, len in
+    let surface = Unmanaged<GhosttySurface>
+        .fromOpaque(ctx!).takeUnretainedValue()
+    surface.handleWrite(data, length: len)
+}
+```
+
+---
+
+### Ghostty: String Handling with Sentinel Tracking
+
+Ghostty's `ghostty_string_s` tracks whether the string has a null sentinel, so the receiving side knows how to handle deallocation:
+
+```zig
+pub const String = extern struct {
+    ptr: [*]const u8,
+    len: usize,
+    has_sentinel: bool,
+};
+```
+
+When `has_sentinel` is true, the pointer points to a null-terminated buffer and the receiver can pass it directly to C string functions. When false, the receiver must use the length and cannot assume null termination. This matters for deallocation -- a sentinel-terminated string may have been allocated with `dupeZ` and needs the sentinel byte accounted for.
+
+---
+
+### Ghostty: Hand-Written Header + module.modulemap for Swift
+
+Ghostty does not generate C headers. The chain to Swift is:
+
+1. **Zig export fn** -- Functions with C linkage in `embedded.zig`
+2. **Hand-written ghostty.h** -- C header declaring all exported types and functions
+3. **module.modulemap** -- Clang module map that wraps ghostty.h:
+
+```
+// module.modulemap
+module GhosttyKit {
+    header "ghostty.h"
+    export *
+}
+```
+
+4. **Swift imports** -- `import GhosttyKit` makes all declarations available
+
+This is the standard pattern for exposing any C-compatible library to Swift. The module.modulemap is required for Swift Package Manager and Xcode framework integration.
+
+Ghostty also generates an XCFramework bundle for multi-architecture support (macOS + iOS), bundling the header, module.modulemap, and architecture-specific static libraries.
+
+---
+
+### Multi-Language Client Pattern (TigerBeetle)
+
+TigerBeetle compiles one Zig core into platform-specific static libraries, then each language client (Go, Rust, Python, Java, .NET, Node.js) links the `.a` and calls through the C ABI. This is the most ambitious production example of "Zig as a polyglot library engine."
+
+#### Architecture
+
+1. **Zig core** compiles to a static `.a` library per platform/architecture
+2. **Comptime binding generators** (`rust_bindings.zig`, `go_bindings.zig`, etc.) emit idiomatic type definitions in each target language — `#[repr(C)]` Rust structs, layout-compatible Go structs, etc.
+3. **Each language client** links the static lib and imports the generated types
+4. **Zero-deserialization** — generated structs are byte-for-byte compatible with the C structs, so responses from Zig map directly onto client-language structs without copying or parsing
+
+#### u128 ABI Workaround
+
+TigerBeetle passes `u128` values as `[16]u8` across the C boundary. The `u128` type is "prone to ABI issues" (per TigerBeetle's own comments) — different compilers disagree on register allocation and alignment for 128-bit integers passed by value. Encoding as a byte array sidesteps all of it.
+
+#### String Passing
+
+Strings cross the boundary as `*const c_char` + `u32` length. No null-terminator dependency — the length field is authoritative. This avoids the ambiguity of whether the receiver should scan for a terminator.
+
+#### Build Integration
+
+- **Rust:** `build.rs` links the pre-built static lib with `cargo:rustc-link-lib=static=tigerbeetle`
+- **Go:** cgo links with `#cgo LDFLAGS: -L... -ltigerbeetle`
+- **Other clients:** similar pre-built `.a` linking; no client compiles Zig source
+
+#### Error Passing
+
+Status codes are `enum(c_int)` on the Zig side. Each language client converts them to idiomatic error types — Rust `enum`, Go `error`, Python exception, etc.
+
+---
+
+### export fn Mechanics
+
+Mark a function with `export` for C linkage (implies `callconv(.c)`). Prefix all exported symbols with a library name to avoid collisions in C's global namespace. For function pointers in structs or callbacks, annotate with `callconv(.c)` explicitly.
+
+---
+
+### Memory Ownership
+
+For every allocation the library makes that the consumer receives, provide a corresponding free function. State the contract in the header:
+
+- **Library-allocated, caller-frees** -- Provide a `_free` function
+- **Caller-allocated, caller-frees** -- Library writes into a caller-provided buffer
+- **Library-allocated, library-frees** -- Arena-based; document when memory becomes invalid
+
+TigerBeetle takes a fourth approach: use `std.heap.c_allocator` on the Zig side so both Zig and the client language allocate through the same C runtime allocator. This eliminates cross-language allocator coordination — there is only one allocator. The tradeoff is losing Zig's safety-checked allocators (GeneralPurposeAllocator, etc.) at the boundary.
+
+Thread safety: decide and document the model. libxev uses per-loop thread safety -- each loop instance is bound to one thread, no locks needed internally.
+
+---
+
+See also: `references/cimport-and-type-mapping.md` for the type mapping rules consumers use when calling your exported API, `references/cpp-shim-patterns.md` for the reverse direction.


### PR DESCRIPTION
## Background

### bnferguson says
One of the appeals of Zig is how it gets along with other languages. I've struggled in the past to find good examples of how to call certain system libraries via the C interop, so I wanted to put together some guidance by looking at existing projects. This also helped me discover some approaches I wasn't aware of (e.g. doing a C++ shim could be handy for making a Zig OpenFrameworks bridge).

### Claude says
The idiomatic-zig skill covers how to write Zig well, and zig-programming covers language fundamentals and API reference. Neither addresses the hard part of production Zig: how it talks to other languages. The zig-programming skill has basic `@cImport` recipes but nothing on shim layers, code generation, exporting Zig as a C library, or comptime FFI metaprogramming.

This skill fills that gap with patterns extracted from five tier-1 production codebases (Bun, Ghostty, libxev, TigerBeetle, Lightpanda) and seven tier-2 libraries/binding generators (vulkan-zig, ziglua, zig-objc, zig-gobject, zpp, zig.rb, allyourcodebase). It covers seven pattern categories: `@cImport` wrapping, C++ shim layers, exporting Zig as C, cross-language ABI (ObjC/Swift/Rust/Go/Ruby), build system C integration, comptime FFI metaprogramming, and memory ownership across boundaries.

All example code has been compiled and tested against Zig 0.15.2.

## Approach

### bnferguson says
The approach was having it look at a few "Tier 1" projects for the main content and then using "Tier 2" ones to beef up the examples and cover gaps. From there I had Claude use the zig-programmer skill (which has a version-by-version reference for the language) and the idiomatic-zig skill to verify that these examples even worked. I also used this opportunity to get a zls plugin going so the LSP could help in the verification process.

### Claude says
The skill follows the same structure as idiomatic-zig: a routing SKILL.md, six reference files for deep dives, and eight example `.zig` files with runnable tests. The SKILL.md acts as a decision tree — wrapping C? shimming C++? exporting Zig? — pointing to the right reference and example.

Key design choices:
- **Memory ownership** is woven into each reference as a subsection rather than a standalone reference, plus a dedicated example that ties all ownership patterns together
- **`build_c_sources.zig`** is a build.zig template, not a test-runnable file — a deliberate departure since that's the most useful artifact for build integration
- **Comptime FFI and code generation** share one reference since both are "generating Zig bindings at build/compile time"
- **All examples verified on 0.15.2** — the original research targeted 0.14 patterns, and verification caught five breaking changes: `CallingConvention` becoming a tagged union, `usingnamespace` removal, comptime return semantics, extern enum bit-width requirements, and the `alignedAlloc` API change. The `build_c_sources.zig` template was also updated for 0.15's build API (`root_module`, `addLibrary` with `.linkage`, methods on Module instead of Step.Compile).
- Also registers a `zig-skills` marketplace and enables the `zls-lsp` plugin in settings.json

## Reviewer notes
- The commit history is noisy — the skill was accidentally merged to main and had to be reverted, so the branch has a "revert the revert" commit. The diff against main is clean (pure additions).
- During verification, a bug was also found and fixed in the idiomatic-zig skill's `packed_struct.zig` (wrong padding size) — that fix went directly to main in a separate commit.

## Testing plan
- Ran `zig test` on all six standalone examples (28 tests pass on Zig 0.15.2)
- Built a small C library test project to verify `cimport_wrapping.zig` patterns — dedicated `@cImport` module, opaque type wrapping, struct-with-handle all work against real C code (4 tests)
- Built a build system test project to verify `build_c_sources.zig` patterns — `addCSourceFiles`, `addTranslateC`, and dual static/dynamic library output all produce correct artifacts (3 tests, both `.a` and `.dylib` output)
- Invoked the skill in Claude Code and verified SKILL.md loads and references are accessible on demand
- Used the zig-programming skill and zls LSP as cross-checks during verification