### PR TITLE
Fix idiomatic-zig skill for Zig 0.15 Allocator API

### DIFF
--- a/claude/config/skills/idiomatic-zig/SKILL.md
+++ b/claude/config/skills/idiomatic-zig/SKILL.md
@@ -15,7 +15,7 @@ Patterns distilled from two flagship Zig projects:
 - **Ghostty** — GPU-accelerated terminal emulator. SIMD optimization, cache-friendly packed structs, offset-based memory addressing, cross-platform abstraction.
 - **TigerBeetle** — Distributed financial database. Static allocation discipline, assertion-driven safety, deterministic simulation testing, io_uring integration. Their [TIGER_STYLE.md](https://github.com/tigerbeetle/tigerbeetle/blob/main/docs/TIGER_STYLE.md) is one of the best coding style guides ever written.
 
-**Target version:** Zig 0.14+. When using the `zig-programming` skill alongside this one, defer to its version detection for API specifics. Some builtins referenced here (e.g., `@branchHint`) are recent additions.
+**Target version:** Zig 0.15+. When using the `zig-programming` skill alongside this one, defer to its version detection for API specifics. Some builtins referenced here (e.g., `@branchHint`) are recent additions.
 
 ## How to Use This Skill
 

--- a/claude/config/skills/idiomatic-zig/SKILL.md
+++ b/claude/config/skills/idiomatic-zig/SKILL.md
@@ -85,7 +85,7 @@ Key patterns:
 
 Key rules:
 
-- **Two assertions per function minimum.** Assertions are a force multiplier for fuzzing.
+- **Two assertions per function minimum** in production logic. Assertions are a force multiplier for fuzzing. Trivial helpers and wrappers are exempt.
 - **Pair assertions** — Assert the same property in two different code paths (e.g., before write AND after read).
 - **Assert positive AND negative space** — `assert(index < length)` AND `assert(value != sentinel)`.
 - **Split compound assertions** — `assert(a); assert(b);` over `assert(a and b)` for precise diagnostics.
@@ -142,7 +142,7 @@ Follow the [Zig style guide](https://ziglang.org/documentation/master/#Style-Gui
 - **Types**: `TitleCase` — `ArrayList`, `Allocator`
 - **Functions/methods**: `camelCase` — `insertSlice`, `appendAssumeCapacity`
 - **Functions returning `type`**: `TitleCase` — `fn ArrayList(comptime T: type) type`
-- **Variables and constants**: `snake_case` — `max_connections`, `default_timeout_ms`
+- **Variables and constants**: `snake_case` — `max_connections`, `timeout_ms_default`
 - **File names**: `TitleCase.zig` for file-as-struct, `snake_case.zig` for namespace modules
 
 ### Acronyms Are Regular Words
@@ -181,7 +181,7 @@ const IO = @import("IO.zig");
 
 > Full examples in `references/api-design-patterns.md`.
 
-- **Options structs** — When arguments can be mixed up (especially multiple integers), use a config struct. Dependencies stay positional, configuration goes in the struct.
+- **Options structs** — When arguments can be mixed up (especially multiple integers), use an options struct. Dependencies stay positional, configuration goes in the struct.
 - **Tagged unions for state machines** — Express multi-state logic as `union(enum)`, not boolean flags.
 - **Return struct for multiple values** — `struct { row: *Row, cell: *Cell }`.
 - **Callbacks go last** — Mirror control flow. Name with calling function as prefix: `readSector()` / `readSectorCallback()`.

--- a/claude/config/skills/idiomatic-zig/examples/options_struct.zig
+++ b/claude/config/skills/idiomatic-zig/examples/options_struct.zig
@@ -8,10 +8,10 @@ const Allocator = std.mem.Allocator;
 
 pub const Server = struct {
     allocator: Allocator,
-    config: Config,
+    config: Options,
     listener: ?std.posix.socket_t = null,
 
-    pub const Config = struct {
+    pub const Options = struct {
         host: []const u8 = "127.0.0.1",
         port: u16 = 8080,
         max_connections: u32 = 1024,
@@ -21,8 +21,8 @@ pub const Server = struct {
     };
 
     /// Dependencies are positional (unique types, can't be mixed up).
-    /// Configuration uses a struct (multiple integers that could be swapped).
-    pub fn init(allocator: Allocator, config: Config) !Server {
+    /// Configuration uses an options struct (multiple integers that could be swapped).
+    pub fn init(allocator: Allocator, config: Options) !Server {
         return .{
             .allocator = allocator,
             .config = config,

--- a/claude/config/skills/idiomatic-zig/examples/static_allocator.zig
+++ b/claude/config/skills/idiomatic-zig/examples/static_allocator.zig
@@ -12,6 +12,7 @@
 const std = @import("std");
 const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
+const Alignment = std.mem.Alignment;
 
 pub const StaticAllocator = struct {
     state: State = .init,
@@ -46,25 +47,31 @@ pub const StaticAllocator = struct {
     const vtable = Allocator.VTable{
         .alloc = alloc,
         .resize = resize,
+        .remap = noRemap,
         .free = free,
     };
 
-    fn alloc(ctx: *anyopaque, len: usize, ptr_align: u8, ret_addr: usize) ?[*]u8 {
+    fn alloc(ctx: *anyopaque, len: usize, alignment: Alignment, ret_addr: usize) ?[*]u8 {
         const self: *StaticAllocator = @ptrCast(@alignCast(ctx));
         assert(self.state == .init); // Allocation only during init.
-        return self.backing.rawAlloc(len, ptr_align, ret_addr);
+        return self.backing.rawAlloc(len, alignment, ret_addr);
     }
 
-    fn resize(ctx: *anyopaque, buf: []u8, buf_align: u8, new_len: usize, ret_addr: usize) bool {
+    fn resize(ctx: *anyopaque, memory: []u8, alignment: Alignment, new_len: usize, ret_addr: usize) bool {
         const self: *StaticAllocator = @ptrCast(@alignCast(ctx));
         assert(self.state == .init); // Resize only during init.
-        return self.backing.rawResize(buf, buf_align, new_len, ret_addr);
+        return self.backing.rawResize(memory, alignment, new_len, ret_addr);
     }
 
-    fn free(ctx: *anyopaque, buf: []u8, buf_align: u8, ret_addr: usize) void {
+    // Remap not supported — we don't allow relocation.
+    fn noRemap(_: *anyopaque, _: []u8, _: Alignment, _: usize, _: usize) ?[*]u8 {
+        return null;
+    }
+
+    fn free(ctx: *anyopaque, memory: []u8, alignment: Alignment, ret_addr: usize) void {
         const self: *StaticAllocator = @ptrCast(@alignCast(ctx));
         assert(self.state != .static); // No free during production.
-        self.backing.rawFree(buf, buf_align, ret_addr);
+        self.backing.rawFree(memory, alignment, ret_addr);
     }
 };
 

--- a/claude/config/skills/idiomatic-zig/references/api-design-patterns.md
+++ b/claude/config/skills/idiomatic-zig/references/api-design-patterns.md
@@ -166,6 +166,9 @@ const OpenGLRenderer = Renderer(OpenGLAPI);
 
 Have each backend provide the required types and methods at comptime.
 
+> Note: Ghostty uses `Renderer` rather than `RendererType`. The `FooType` suffix is a TigerBeetle
+> convention. Both are common in practice — pick one and be consistent within a codebase.
+
 ## Platform Selection at Comptime
 
 ```zig

--- a/claude/config/skills/idiomatic-zig/references/safety-and-assertions.md
+++ b/claude/config/skills/idiomatic-zig/references/safety-and-assertions.md
@@ -30,9 +30,9 @@ trade-offs. The universally applicable ones are marked with **[universal]**; the
 
 ## Assertion Density
 
-Target a minimum of **two assertions per function**. Assertions are a force multiplier for fuzzing —
-they downgrade catastrophic correctness bugs into liveness bugs (crashes instead of silent
-corruption).
+Target a minimum of **two assertions per function** in production logic. Trivial helpers, wrappers,
+and simple delegating functions are exempt. Assertions are a force multiplier for fuzzing — they
+downgrade catastrophic correctness bugs into liveness bugs (crashes instead of silent corruption).
 
 ```zig
 fn processTransaction(txn: *const Transaction, ledger: *Ledger) !void {

--- a/claude/config/skills/idiomatic-zig/references/tiger-style-principles.md
+++ b/claude/config/skills/idiomatic-zig/references/tiger-style-principles.md
@@ -37,7 +37,7 @@ This is the only way to make steady progress.
 ## Safety (NASA Power of Ten, Adapted)
 
 > Note: These rules come from safety-critical infrastructure. Most are universally good practice,
-> but rules 1, 3, and 5 are domain-specific choices that diverge from general Zig practice. See
+> but rules 3 and 5 are domain-specific choices that diverge from general Zig practice. See
 > `safety-and-assertions.md` for detailed guidance on when each applies.
 
 1. **Simple, explicit control flow.** Minimum of excellent abstractions. Abstractions


### PR DESCRIPTION
## Summary

Audit of the idiomatic-zig skill against Zig 0.15.2 — compiled all examples, verified API claims, and fixed internal prose inconsistencies.

### Code fixes
- **`static_allocator.zig`** — Zig 0.15 changed `Allocator.VTable` to use `mem.Alignment` (enum) instead of `u8` for alignment params and added a required `remap` field. Updated the example accordingly.
- **Bumped target version** in `SKILL.md` from "0.14+" to "0.15+".

### Prose consistency fixes
- **NASA Power of Ten Rule 1** was classified as `[domain]` in `tiger-style-principles.md` but `[universal]` in `safety-and-assertions.md` — now consistent (`[universal]` in both).
- **Options struct naming** — renamed `Config` to `Options` in `options_struct.zig` to match the "options struct" terminology used throughout the prose. Fixed SKILL.md saying "config struct" in the same sentence.
- **Qualifiers-last example** — `default_timeout_ms` in SKILL.md contradicted the "units/qualifiers last" rule stated 22 lines later. Changed to `timeout_ms_default`.
- **Assertion density rule** — qualified "two assertions per function minimum" as applying to production logic, exempting trivial helpers. The examples were already written this way; the prose now matches.
- **`FooType` convention** — added a note that Ghostty uses `Renderer()` rather than `RendererType()`, acknowledging both conventions are valid.

## Test plan

- [x] All 8 example `.zig` files compile and pass tests on Zig 0.15.2 (18 tests total)
- [x] All API claims in reference docs verified (`@branchHint`, `std.atomic.Value`, `std.heap.MemoryPool`, `mem.Alignment`, etc.)
- [x] Prose consistency checked across SKILL.md, 6 reference docs, and 8 example files