### PR TITLE
Prefer LSP over grep/glob for code navigation across agents

### DIFF
--- a/claude/config/CLAUDE.md
+++ b/claude/config/CLAUDE.md
@@ -42,7 +42,14 @@ The exception here is when you notice the code is getting messy or needs to be r
 - Use `git` for source control
 - I use `mise` to manage my shell environment for projects
 - I use `brew` to install tools that aren't specified in `mise`
-- When dealing with code structure use `ast-grep` an LSP for the given language when available
+- When dealing with code structure use `ast-grep` and LSP for the given language when available
+- **Prefer the LSP tool over grep/glob for code navigation.** When you need to understand how code connects — finding definitions, references, implementations, callers, or type info — use LSP first. It's faster and more accurate than text search for these tasks. Reserve grep/glob for text pattern matching, searching across files by content, or when LSP isn't available for the language. Specific guidance:
+  - **Go to definition / type:** Use `LSP goToDefinition` instead of grepping for `func FooBar` or `class FooBar`
+  - **Find all usages:** Use `LSP findReferences` instead of grepping for a symbol name
+  - **Understand a symbol:** Use `LSP hover` to get type info and docs
+  - **Map a file's structure:** Use `LSP documentSymbol` instead of grepping for `def ` or `func `
+  - **Find implementations:** Use `LSP goToImplementation` for interfaces/abstract methods
+  - **Trace call chains:** Use `LSP incomingCalls`/`outgoingCalls` to understand call graphs
 - When dealing with terraform use the Terraform MCP
 - When working with Rails use the `rails` command for migrations and generators
 

--- a/claude/config/agents/application-architect.md
+++ b/claude/config/agents/application-architect.md
@@ -1,7 +1,7 @@
 ---
 name: application-architect
 description: Use proactively for designing non-trivial features requiring architectural planning. Specialist for transforming user requirements into detailed implementation approaches, researching libraries, and creating elegant system designs.
-tools: Read, Grep, Glob, WebSearch, WebFetch, Write
+tools: Read, Grep, Glob, LSP, WebSearch, WebFetch, Write
 model: opus
 color: purple
 ---
@@ -31,6 +31,7 @@ You believe in code that is:
 
 2. **Study the Existing Architecture**
    - Read `/docs/architecture.md` to understand current patterns
+   - Use the LSP tool to map interfaces, call hierarchies, and type relationships (`documentSymbol`, `goToImplementation`, `incomingCalls`, `outgoingCalls`) — prefer LSP over grep for structural code navigation
    - Examine relevant existing code using Grep and Read:
      - Controllers in `/app/controllers/`
      - Svelte components in `/app/frontend/`

--- a/claude/config/agents/go-core-code-reviewer.md
+++ b/claude/config/agents/go-core-code-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: go-core-code-reviewer
 description: Use this agent whenever new Go code has been written by yourself or a sub-agent, to review it against the Go team's exacting standards for simplicity, clarity, and mechanical sympathy. This agent should always be invoked after writing or modifying Go code to ensure it meets the standards exemplified in the Go standard library and tools like Docker/moby. Examples:\n\n<example>\nContext: The user has just written a new HTTP handler.\nuser: "Please implement an API endpoint for deployment status"\nassistant: "Here's the deployment status handler:"\n<function call omitted for brevity>\n<commentary>\nSince new Go code was just written, use the go-core-code-reviewer agent to ensure it meets Go team standards.\n</commentary>\nassistant: "Now let me review this code against Go team standards using the code reviewer agent"\n</example>\n\n<example>\nContext: The user has refactored a concurrency pattern.\nuser: "Refactor the worker pool to use errgroup"\nassistant: "I've refactored the worker pool:"\n<function call omitted for brevity>\n<commentary>\nAfter refactoring Go code, use the go-core-code-reviewer to verify the changes meet Go standards.\n</commentary>\nassistant: "I'll now review these changes against Go team standards"\n</example>
-tools: Glob, Grep, LS, Read, WebFetch, TodoWrite, WebSearch, BashOutput, KillBash, Write
+tools: Glob, Grep, LS, LSP, Read, WebFetch, TodoWrite, WebSearch, BashOutput, KillBash, Write
 model: opus
 color: cyan
 ---

--- a/claude/config/agents/go-core-code-reviewer.md
+++ b/claude/config/agents/go-core-code-reviewer.md
@@ -35,6 +35,8 @@ These aren't suggestions — they're the DNA of good Go:
 
 ## Your Review Process
 
+0. **Use LSP for navigation**: When tracing code — finding definitions, references, implementations, callers — use the LSP tool (`goToDefinition`, `findReferences`, `goToImplementation`, `incomingCalls`, `hover`) instead of grepping for symbol names. LSP gives you precise, compiler-accurate results.
+
 1. **First Impression**: Read the code as a Go team member reviewing a CL (changelist). Ask:
    - Does this look like it belongs in the standard library?
    - Can I understand the intent without comments?

--- a/claude/config/agents/meta-agent.md
+++ b/claude/config/agents/meta-agent.md
@@ -19,7 +19,7 @@ Your sole purpose is to act as an expert agent architect. You will take a user's
 **2. Devise a Name:** Create a concise, descriptive, `kebab-case` name for the new agent (e.g., `dependency-manager`, `api-tester`).
 **3. Select a color:** Choose between: red, blue, green, yellow, purple, orange, pink, cyan and set this in the frontmatter 'color' field.
 **4. Write a Delegation Description:** Craft a clear, action-oriented `description` for the frontmatter. This is critical for Claude's automatic delegation. It should state *when* to use the agent. Use phrases like "Use proactively for..." or "Specialist for reviewing...".
-**5. Infer Necessary Tools:** Based on the agent's described tasks, determine the minimal set of `tools` required. For example, a code reviewer needs `Read, Grep, Glob`, while a debugger might need `Read, Edit, Bash`. If it writes new files, it needs `Write`.
+**5. Infer Necessary Tools:** Based on the agent's described tasks, determine the minimal set of `tools` required. For example, a code reviewer needs `Read, Grep, Glob`, while a debugger might need `Read, Edit, Bash`. If it writes new files, it needs `Write`. **Include `LSP` for any agent that navigates or analyzes code** (reviewers, architects, test writers, etc.) — LSP provides precise go-to-definition, find-references, and call hierarchy operations that are more accurate than text search.
 **6. Construct the System Prompt:** Write a detailed system prompt (the main body of the markdown file) for the new agent.
 **7. Provide a numbered list** or checklist of actions for the agent to follow when invoked.
 **8. Incorporate best practices** relevant to its specific domain.

--- a/claude/config/agents/rails-core-code-reviewer.md
+++ b/claude/config/agents/rails-core-code-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: rails-core-code-reviewer
 description: Use this agent whenever new code has been written by yourself or a sub-agent, to review Ruby or JavaScript code against the Rails Core Team's exacting standards for code quality, as exemplified in the Rails and Hotwire codebases. This agent should always be invoked after writing or modifying Ruby/Rails and Javascript/Svelte code to ensure it meets the highest standards of elegance, expressiveness, and idiomatic style. Examples:\n\n<example>\nContext: The user has just written a new Rails controller action.\nuser: "Please implement a controller action to handle user subscriptions"\nassistant: "Here's the subscription controller implementation:"\n<function call omitted for brevity>\n<commentary>\nSince new controller code was just written, use the rails-core-code-reviewer agent to ensure it meets Rails Core Team's standards for Rails code.\n</commentary>\nassistant: "Now let me review this code against Rails Core Team's standards using the code reviewer agent"\n</example>\n\n<example>\n\n<example>\nContext: The user has refactored an existing model.\nuser: "Refactor the User model to extract authentication logic"\nassistant: "I've refactored the User model and extracted the authentication concerns:"\n<function call omitted for brevity>\n<commentary>\nAfter refactoring any code, use the rails-core-code-reviewer again to verify the refactoring meets Rails standards.\n</commentary>\nassistant: "I'll now review these changes against Rails Core Team's standards for code elegance"\n</example>
-tools: Glob, Grep, LS, Read, WebFetch, TodoWrite, WebSearch, BashOutput, KillBash, Write
+tools: Glob, Grep, LS, LSP, Read, WebFetch, TodoWrite, WebSearch, BashOutput, KillBash, Write
 model: opus
 color: red
 ---

--- a/claude/config/agents/rails-core-code-reviewer.md
+++ b/claude/config/agents/rails-core-code-reviewer.md
@@ -20,6 +20,8 @@ You believe in code that is:
 
 ## Your Review Process
 
+0. **Use LSP for navigation**: When tracing code — finding definitions, references, callers, or type info — use the LSP tool (`goToDefinition`, `findReferences`, `incomingCalls`, `hover`, `documentSymbol`) instead of grepping for symbol names. LSP gives you precise, semantically-accurate results.
+
 1. **Initial Assessment**: Scan the code for immediate red flags:
    - Unnecessary complexity or cleverness
    - Violations of Rails conventions

--- a/claude/config/agents/test-writer.md
+++ b/claude/config/agents/test-writer.md
@@ -1,7 +1,7 @@
 ---
 name: test-writer
 description: Use for writing automated tests. Invoke with specific test type: Rails integration tests, model/service/API tests, Svelte unit tests, or Playwright component tests. Invoke whenever new functionality is built and needs testing, or when existing functionality is changed. Pass in the context of the changes that have been made and need testing, and the test type to write.
-tools: Read, Grep, Glob, Write, MultiEdit, Bash, WebFetch
+tools: Read, Grep, Glob, LSP, Write, MultiEdit, Bash, WebFetch
 model: opus
 color: green
 ---
@@ -28,6 +28,7 @@ When invoked, you must follow these steps:
 
 3. **Analyze the component to test**: 
    - Read the implementation code thoroughly
+   - Use the LSP tool to trace dependencies (`goToDefinition`, `findReferences`, `incomingCalls`) rather than grepping for symbol names — this gives precise, compiler-accurate results
    - Understand all dependencies and interactions
    - Map out the critical paths that need testing
 

--- a/claude/config/agents/zig-core-code-reviewer.md
+++ b/claude/config/agents/zig-core-code-reviewer.md
@@ -35,6 +35,8 @@ These aren't suggestions — they're the DNA of good Zig:
 
 ## Your Review Process
 
+0. **Use LSP for navigation**: When tracing code — finding definitions, references, implementations, callers — use the LSP tool (`goToDefinition`, `findReferences`, `goToImplementation`, `incomingCalls`, `hover`) instead of grepping for symbol names. LSP gives you precise, compiler-accurate results.
+
 1. **First Impression**: Read the code as a Zig stdlib maintainer reviewing a patch. Ask:
    - Does this look like it belongs in the standard library or a production Zig codebase?
    - Can I understand the intent without comments?

--- a/claude/config/agents/zig-core-code-reviewer.md
+++ b/claude/config/agents/zig-core-code-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: zig-core-code-reviewer
 description: Use this agent whenever new Zig code has been written by yourself or a sub-agent, to review it against the exacting standards of production Zig codebases — the Zig standard library, Ghostty, and TigerBeetle. This agent should always be invoked after writing or modifying Zig code to ensure it meets the standards for safety, performance, and clarity exemplified by Andrew Kelley, Mitchell Hashimoto, and the TigerBeetle team. Examples:\n\n<example>\nContext: The user has just written a new data structure.\nuser: "Implement a ring buffer for the event queue"\nassistant: "Here's the ring buffer implementation:"\n<function call omitted for brevity>\n<commentary>\nSince new Zig code was just written, use the zig-core-code-reviewer agent to ensure it meets production Zig standards.\n</commentary>\nassistant: "Now let me review this code against production Zig standards using the code reviewer agent"\n</example>\n\n<example>\nContext: The user has written a build.zig configuration.\nuser: "Set up the build system to cross-compile with C interop"\nassistant: "Here's the build.zig configuration:"\n<function call omitted for brevity>\n<commentary>\nAfter writing Zig build system code, use the zig-core-code-reviewer to verify it meets standards.\n</commentary>\nassistant: "I'll now review this build configuration against production Zig standards"\n</example>
-tools: Glob, Grep, LS, Read, WebFetch, TodoWrite, WebSearch, BashOutput, KillBash, Write
+tools: Glob, Grep, LS, LSP, Read, WebFetch, TodoWrite, WebSearch, BashOutput, KillBash, Write
 model: opus
 color: green
 ---


### PR DESCRIPTION
## Background

Claude Code has LSP plugins configured for Go, TypeScript, Ruby, Zig, and C/C++, but in practice the LSP tool almost never gets used. The existing CLAUDE.md guidance was too vague ("use `ast-grep` an LSP for the given language when available") to change the default behavior, and subagents had no LSP tool access at all — so even if the main conversation started using LSP, the reviewer, test-writer, and architect agents couldn't.

## Approach

Three layers of change to make LSP the default for code navigation:

1. **CLAUDE.md** — explicit LSP-first guidance with specific operation-to-use-case mapping (e.g., "use `LSP goToDefinition` instead of grepping for `func FooBar`")
2. **Agent tool access** — added `LSP` to the tools list for all 6 agents that navigate code (3 reviewers, test-writer, application-architect)
3. **Agent prompt guidance** — since subagents don't inherit CLAUDE.md, each agent got its own LSP-first instruction in its review/analysis process
4. **Meta-agent** — taught to include LSP by default when generating new agents that analyze code, so future agents don't repeat this gap

## Reviewer notes

- Grep/glob are still the right tool for text pattern matching and cross-file content search — the guidance is specifically about *code navigation* (definitions, references, call chains, type info)
- The reviewer agents got both tool access (commit 2) and prompt guidance (commit 3) as separate commits since they're logically distinct changes

## Testing plan

- [ ] Verify LSP is used in a Go/Ruby/Zig code review by spawning a reviewer agent
- [ ] Verify the meta-agent includes LSP when generating a new code-analysis agent
- [ ] Spot check that grep/glob still get used for text search tasks