### PR TITLE
Add connascence analysis skill for coupling assessment

### DIFF
--- a/claude/config/skills/connascence/SKILL.md
+++ b/claude/config/skills/connascence/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: connascence
+description: Assess coupling in code using the connascence taxonomy. Use when reviewing code for coupling issues, planning refactors, evaluating design decisions, or when the user mentions "connascence", "coupling", or asks about dependencies between components. Focused on Ruby, Go, Zig, and TypeScript but applicable to any language.
+---
+
+# Connascence Analysis
+
+## Overview
+
+This skill applies the connascence framework to assess coupling in code. Connascence gives a precise vocabulary for different kinds of coupling, ordered by strength, so you can make informed decisions about what to refactor and what to leave alone.
+
+## When to Use This Skill
+
+- User explicitly asks for connascence analysis
+- User asks about coupling, dependencies, or why something is hard to change
+- During code review when coupling patterns affect maintainability
+- When planning a refactor and you need to prioritize what to address
+- When evaluating a design decision that introduces new coupling
+
+## Setup
+
+Load the reference material before analysis:
+
+```
+Read references/taxonomy.md
+Read references/refactoring-guide.md
+```
+
+## Analysis Workflow
+
+### 1. Identify the Scope
+
+Determine what you are analyzing:
+- A single file or class — look for internal connascence and connascence with direct dependencies
+- A module boundary or API surface — focus on what crosses the boundary
+- A PR diff — assess whether changes introduce stronger connascence or increase degree
+- A design proposal — evaluate what connascence the design would create
+
+### 2. Scan for Connascence
+
+Work from strongest to weakest — strong connascence crossing wide boundaries is the highest-value finding.
+
+**Priority order for findings:**
+
+| Priority | What to look for |
+|---|---|
+| Critical | Dynamic connascence (CoE, CoTm, CoV, CoI) crossing module/service boundaries |
+| High | CoA (Algorithm) duplicated across modules or languages |
+| High | CoP (Position) in public APIs with many callers |
+| Medium | CoM (Meaning) — magic values, sentinel returns, implicit conventions |
+| Low | CoT, CoN within a module — usually acceptable |
+
+**Do not flag:**
+- CoN (Name) unless renaming would cascade across an unusual number of files
+- Any connascence that is purely internal to a small function or method
+- Connascence that is an inherent consequence of the language or framework (e.g., positional args in a language without keyword support)
+
+### 3. Measure with LSP
+
+When an LSP is available, use it to quantify degree and locality before assessing findings. This turns gut-feel estimates into concrete numbers.
+
+**Degree measurement:**
+- Use "Find all references" on the coupled symbol (method, constant, type) to count how many components depend on it. A function with CoP and 3 callers is different from one with 34 callers across 8 packages.
+- Use "Type hierarchy" to see how many implementations exist for an interface — this is the degree of CoN/CoT on that contract.
+
+**Locality measurement:**
+- Use "Call hierarchy" (incoming) to see where callers live. If all callers are in the same package, locality is tight and the finding is less urgent. If they span modules or services, it's a boundary-crossing problem.
+
+**Rename testability:**
+- Use "Rename symbol" as a probe. If the LSP can handle the rename cleanly, CoN is mechanical and well-managed. If it can't (cross-language refs, string-based lookups, generated code), that signals the coupling is worse than it appears structurally.
+
+Skip this step when reviewing a single small file or a design proposal where the code doesn't exist yet.
+
+### 4. Assess Each Finding
+
+For each instance worth reporting, note:
+
+- **Type** — which of the 9 forms (use the abbreviation: CoN, CoT, CoM, CoP, CoA, CoE, CoTm, CoV, CoI)
+- **Locality** — where the coupled components are relative to each other (same function, same class, same module, cross-module, cross-service). Use LSP call hierarchy data when available.
+- **Degree** — how many components are involved. Use LSP reference counts when available.
+- **Verdict** — acceptable (and why) or worth addressing (and why)
+
+### 5. Suggest Transformations
+
+For findings worth addressing, consult `references/refactoring-guide.md` and suggest a specific transformation:
+
+- Name the target form (e.g., "convert CoP → CoN by using keyword arguments")
+- Show a concrete before/after
+- Note if the transformation has tradeoffs (e.g., introducing a struct to eliminate CoP adds a type to maintain)
+
+### 6. Prioritize
+
+Order recommendations by impact:
+1. Strong connascence crossing wide boundaries (fix first)
+2. High-degree connascence regardless of strength (many components affected)
+3. Connascence that is likely to cause bugs (especially dynamic forms)
+4. Connascence that makes the code hard to change (affects velocity)
+
+## Reporting Format
+
+Structure findings as:
+
+```
+## Connascence Assessment: [scope]
+
+### Findings
+
+#### [Finding title]
+- **Type:** CoX (Connascence of X)
+- **Strength:** [weak/medium/strong]
+- **Locality:** [within function / within class / cross-module / cross-service]
+- **Degree:** [number of components involved]
+- **Assessment:** [acceptable / worth addressing]
+
+[Brief explanation of what is coupled and why it matters or doesn't]
+
+[If worth addressing: suggested transformation with before/after]
+
+### Summary
+
+[1-2 sentences: overall coupling health and top recommendation]
+```
+
+## Things to Remember
+
+- Connascence is a lens for prioritization, not a score to minimize. Some coupling is necessary and fine.
+- The locality corollary: acceptable strength decreases as distance increases. CoA within a class may be fine; CoA across services is a problem.
+- Dynamic connascence (CoE, CoTm, CoV, CoI) is inherently harder to reason about than static. Flag it even at close locality.
+- When analyzing a PR diff, focus on *changes* to connascence — did the PR introduce stronger coupling? Did it increase degree? That matters more than pre-existing coupling.
+- Be honest about the limits of static analysis for dynamic connascence types. You can identify *likely* CoTm from shared mutable state + concurrency, but you cannot be certain without runtime analysis.

--- a/claude/config/skills/connascence/references/refactoring-guide.md
+++ b/claude/config/skills/connascence/references/refactoring-guide.md
@@ -1,0 +1,280 @@
+# Connascence Refactoring Guide
+
+## Core Principles
+
+1. **Weaken** — convert stronger connascence to weaker forms
+2. **Reduce degree** — minimize the number of components involved
+3. **Localize** — move coupled components closer together
+4. **Convert dynamic to static** — make runtime coupling visible in source code
+
+The acceptable strength of connascence decreases as distance increases:
+
+| Boundary | Acceptable Strength |
+|---|---|
+| Within a function | Any static form; weak dynamic |
+| Within a class/module | CoN, CoT, CoM, CoP; avoid CoA |
+| Across modules | CoN, CoT only |
+| Across services/repos | CoN only (via shared contracts) |
+
+---
+
+## Transformation Patterns
+
+### CoM (Meaning) → CoN (Name)
+
+**Problem:** Magic values whose meaning is implicit.
+
+**Pattern:** Extract named constants, enums, or types.
+
+```ruby
+# Before: CoM — callers must know 2 means admin
+user.update(role: 2)
+
+# After: CoN — callers reference a name
+user.update(role: Roles::ADMIN)
+```
+
+```go
+// Before: CoM
+SetLogLevel(3) // what is 3?
+
+// After: CoN
+type LogLevel int
+const (
+    Debug LogLevel = iota
+    Info
+    Warn
+    Error
+)
+SetLogLevel(Warn)
+```
+
+```zig
+// Before: CoM — sentinel value
+fn find(haystack: []const u8, needle: u8) i32 { ... } // -1 = not found
+
+// After: CoT — optional type encodes the meaning
+fn find(haystack: []const u8, needle: u8) ?usize { ... } // null = not found
+```
+
+```typescript
+// Before: CoM
+fetch("/api/users", { method: "POST" }) // string convention
+
+// After: CoT
+type HttpMethod = "GET" | "POST" | "PUT" | "DELETE"
+function apiFetch(url: string, method: HttpMethod) { ... }
+```
+
+---
+
+### CoP (Position) → CoN (Name)
+
+**Problem:** Callers must remember argument/element order.
+
+**Pattern:** Use keyword arguments, named structs, or objects.
+
+```ruby
+# Before: CoP — 6 positional args
+send_email("user@example.com", "admin@co.com", "Alert", "Body", nil, nil)
+
+# After: CoN — keyword args
+send_email(to: "user@example.com", from: "admin@co.com", subject: "Alert", body: "Body")
+```
+
+```go
+// Before: CoP — positional returns
+func ParseAddr(s string) (string, int, bool, error) { ... }
+host, port, tls, err := ParseAddr(addr) // must match order
+
+// After: CoN — named struct
+type Addr struct { Host string; Port int; TLS bool }
+func ParseAddr(s string) (Addr, error) { ... }
+addr, err := ParseAddr(s)
+fmt.Println(addr.Host) // access by name
+```
+
+```zig
+// Before: CoP — anonymous struct return
+fn parseEndpoint(raw: []const u8) struct { []const u8, u16 } { ... }
+
+// After: CoN — named struct
+const Endpoint = struct { host: []const u8, port: u16 };
+fn parseEndpoint(raw: []const u8) Endpoint { ... }
+```
+
+```typescript
+// Before: CoP — tuple return
+function useForm(): [string, (v: string) => void, () => void] { ... }
+
+// After: CoN — object return
+function useForm(): { value: string; setValue: (v: string) => void; reset: () => void } { ... }
+```
+
+---
+
+### CoA (Algorithm) → Single Source of Truth
+
+**Problem:** The same algorithm is implemented independently in multiple places.
+
+**Pattern:** Extract the shared logic into one location. Both sides call it.
+
+```ruby
+# Before: CoA — serialization duplicated
+class Writer
+  def save(data) = Redis.set(key, Marshal.dump(data)) end
+end
+class Reader
+  def load = Marshal.load(Redis.get(key)) end
+end
+
+# After: shared codec
+module Codec
+  def self.encode(data) = Marshal.dump(data)
+  def self.decode(raw)  = Marshal.load(raw)
+end
+```
+
+```go
+// Before: CoA — HMAC logic in two places
+func sign(body, secret []byte) string { /* sha256 HMAC */ }
+func verify(body, secret []byte, sig string) bool { /* sha256 HMAC again */ }
+
+// After: sign once, compare
+func verify(body, secret []byte, sig string) bool {
+    return hmac.Equal([]byte(sign(body, secret)), []byte(sig))
+}
+```
+
+```zig
+// Before: CoA — encode/decode must agree on byte order
+fn encode(val: u32, buf: *[4]u8) void { std.mem.writeInt(u32, buf, val, .big); }
+fn decode(buf: *const [4]u8) u32 { return std.mem.readInt(u32, buf, .big); }
+
+// After: shared constant
+const byte_order: std.builtin.Endian = .big;
+fn encode(val: u32, buf: *[4]u8) void { std.mem.writeInt(u32, buf, val, byte_order); }
+fn decode(buf: *const [4]u8) u32 { return std.mem.readInt(u32, buf, byte_order); }
+```
+
+```typescript
+// Before: CoA — token format in frontend and backend
+// frontend: btoa(JSON.stringify({sub, iat}))
+// backend: Buffer.from(token, 'base64').toString()
+
+// After: shared module
+export const Token = {
+  encode: (payload: TokenPayload) => btoa(JSON.stringify(payload)),
+  decode: (token: string): TokenPayload => JSON.parse(atob(token)),
+}
+```
+
+---
+
+### CoE (Execution Order) → Builder / State Machine
+
+**Problem:** Methods must be called in a specific order, but nothing enforces it.
+
+**Pattern:** Use a builder that enforces the sequence through types, or a state machine that rejects invalid transitions.
+
+```ruby
+# Before: CoE — must call in order
+email = Mail.new
+email.to = "user@example.com"
+email.subject = "Hello"
+email.deliver!
+
+# After: builder enforces required fields
+Mail.deliver(to: "user@example.com", subject: "Hello", body: "...")
+```
+
+```go
+// Before: CoE — must register before listen
+http.HandleFunc("/health", handler)
+srv.ListenAndServe()
+
+// After: constructor takes complete config
+func NewServer(routes map[string]http.Handler) *http.Server { ... }
+```
+
+```typescript
+// Before: CoE — middleware order matters
+app.use(cors())
+app.use(auth())
+app.use(routes)
+
+// After: framework enforces phases
+createApp({ middleware: [cors(), auth()], routes })
+```
+
+---
+
+### CoTm (Timing) → Synchronization / Message Passing
+
+**Problem:** Correctness depends on when operations happen relative to each other.
+
+**Pattern:** Replace shared mutable state with synchronization primitives, channels, or immutable message passing.
+
+```go
+// Before: CoTm — race condition
+var balance int64
+go func() { balance += 100 }()
+go func() { balance -= 50 }()
+
+// After: channel-based coordination
+func updateBalance(ch chan int64, delta int64) { ch <- delta }
+```
+
+```zig
+// Before: CoTm — unsynchronized shared state
+var shared: u64 = 0;
+// threads racing on shared
+
+// After: atomic or mutex
+var shared = std.atomic.Value(u64).init(0);
+```
+
+---
+
+### CoI (Identity) → Dependency Injection / Interface
+
+**Problem:** Components must reference the exact same instance.
+
+**Pattern:** Make the shared identity explicit through DI, or decouple via interfaces so components don't need the same instance.
+
+```ruby
+# Before: CoI — must be the same logger instance
+OrderService.new(logger)
+AuditService.new(logger)
+
+# After: interface — any conforming logger works
+class OrderService
+  def initialize(logger:) # accepts anything that responds to :info, :error
+    @logger = logger
+  end
+end
+```
+
+```go
+// Before: CoI — must share exact *sql.DB
+NewOrderRepo(db)
+NewAuditRepo(db)
+
+// After: interface decouples identity requirement
+type Querier interface { QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) }
+func NewOrderRepo(q Querier) *OrderRepo { ... }
+```
+
+---
+
+## Decision Heuristic
+
+When you find connascence, ask:
+
+1. **Is it crossing a boundary?** If it is within a single function or small class, it may be fine regardless of strength.
+2. **What is the degree?** Two components sharing CoA is manageable; twenty sharing it is urgent.
+3. **Can I weaken it?** Look one or two steps down the strength ladder. CoA → extract shared code. CoP → use named args. CoM → introduce constants.
+4. **Can I localize it?** If weakening isn't practical, move the coupled components closer together — same module, same package.
+5. **Is it dynamic?** Dynamic connascence crossing boundaries is the highest-priority target. Convert to static forms where possible.
+
+Not every instance needs fixing. The framework is for prioritization, not elimination.

--- a/claude/config/skills/connascence/references/taxonomy.md
+++ b/claude/config/skills/connascence/references/taxonomy.md
@@ -1,0 +1,478 @@
+# Connascence Taxonomy
+
+Connascence is a software quality metric and taxonomy for coupling. Two components are **connascent** if a change in one requires a change in the other to maintain correctness.
+
+Every instance has three properties:
+
+- **Strength** — how hard it is to discover and refactor. Stronger = worse.
+- **Degree** — how many components are involved. Higher = worse.
+- **Locality** — how close the coupled components are. Farther apart = worse.
+
+These interact: strong connascence within a single function is often fine; the same form crossing a module boundary is a problem.
+
+---
+
+## Strength Ordering (Weakest to Strongest)
+
+### Static (visible in source code)
+
+1. **Name** (CoN) — weakest
+2. **Type** (CoT)
+3. **Meaning** (CoM)
+4. **Position** (CoP)
+5. **Algorithm** (CoA)
+
+### Dynamic (only apparent at runtime)
+
+6. **Execution** (CoE)
+7. **Timing** (CoTm)
+8. **Value** (CoV)
+9. **Identity** (CoI) — strongest
+
+---
+
+## Static Connascence Types
+
+### Connascence of Name (CoN)
+
+Multiple components must agree on the name of an entity. Renaming a method, class, or variable requires updating every reference. This is the weakest form — unavoidable and easily handled by tooling (rename refactors, LSP).
+
+**Ruby:**
+```ruby
+class OrderProcessor
+  def process(order)
+    validate(order)        # CoN: must match method name
+    charge(order.total)    # CoN: must match attribute name
+  end
+end
+```
+
+**Go:**
+```go
+func (s *Service) HandleRequest(w http.ResponseWriter, r *http.Request) {
+    user := s.repo.FindByID(r.Context(), userID) // CoN: FindByID must match repo method
+    s.logger.Info("handled", "user", user.Name)  // CoN: Name must match field
+}
+```
+
+**Zig:**
+```zig
+const allocator = std.heap.page_allocator;
+var list = std.ArrayList(u8).init(allocator); // CoN: init must match ArrayList's API
+try list.append(42);                          // CoN: append must match method name
+```
+
+**TypeScript:**
+```typescript
+interface User { name: string; email: string }
+function greet(user: User) {
+  return `Hello ${user.name}`  // CoN: must match interface field
+}
+```
+
+---
+
+### Connascence of Type (CoT)
+
+Multiple components must agree on the type of an entity. In statically typed languages the compiler enforces this; in dynamic languages the contract is implicit.
+
+**Ruby (implicit — no compiler to help):**
+```ruby
+def calculate_age(birth_year)
+  # Caller could pass "1984", 1984, or Time.new(1984)
+  # The implicit contract is that birth_year is an Integer
+  Time.now.year - birth_year
+end
+```
+
+**Go (explicit — compiler enforces):**
+```go
+func ProcessPayment(amount float64, currency string) error {
+    // Every caller must pass float64 and string — compiler enforced
+    return nil
+}
+```
+
+**Zig (explicit — compiler enforces):**
+```zig
+fn processPayment(amount: f64, currency: []const u8) !void {
+    // Zig's type system enforces this at compile time
+}
+```
+
+**TypeScript (structural typing — partially enforced):**
+```typescript
+function processPayment(amount: number, currency: string): void {
+  // TypeScript checks at compile time, but `any` escapes the contract
+}
+```
+
+---
+
+### Connascence of Meaning (CoM)
+
+Multiple components must agree on the meaning of particular values. Also called Connascence of Convention. Magic numbers, sentinel values, and implicit status codes are the classic symptoms.
+
+**Ruby:**
+```ruby
+# Bad: magic value convention
+def user_role(code)
+  case code
+  when 0 then :guest      # every caller must know 0 = guest
+  when 1 then :member
+  when 2 then :admin
+  end
+end
+
+# Better: named constants reduce to CoN
+module Roles
+  GUEST  = 0
+  MEMBER = 1
+  ADMIN  = 2
+end
+```
+
+**Go:**
+```go
+// Bad: bare int convention
+func SetPermission(level int) { /* 0=none, 1=read, 2=write, 3=admin */ }
+
+// Better: named type + constants
+type Permission int
+const (
+    PermNone  Permission = iota
+    PermRead
+    PermWrite
+    PermAdmin
+)
+func SetPermission(level Permission) {}
+```
+
+**Zig:**
+```zig
+// Bad: magic sentinel
+fn find(haystack: []const u8, needle: u8) i32 {
+    // returns -1 for "not found" — every caller must know this
+}
+
+// Better: optional type eliminates the convention
+fn find(haystack: []const u8, needle: u8) ?usize {
+    // null means not found — the type system encodes the meaning
+}
+```
+
+**TypeScript:**
+```typescript
+// Bad: string convention
+function setStatus(status: string) { /* "active", "inactive", "banned" */ }
+
+// Better: union type reduces to CoT
+type Status = "active" | "inactive" | "banned"
+function setStatus(status: Status) {}
+```
+
+---
+
+### Connascence of Position (CoP)
+
+Multiple components must agree on the order of values. Reordering parameters, tuple elements, or array indices breaks all dependent code.
+
+**Ruby:**
+```ruby
+# Bad: positional — caller must remember order
+def send_email(to, from, subject, body, cc, bcc)
+end
+
+# Better: keyword arguments reduce to CoN
+def send_email(to:, from:, subject:, body:, cc: nil, bcc: nil)
+end
+```
+
+**Go:**
+```go
+// Bad: positional return values
+func ParseConfig(path string) (string, int, bool, error) {
+    // caller must destructure in exact order
+    return host, port, tls, nil
+}
+
+// Better: return a struct (reduces to CoN)
+type Config struct {
+    Host string
+    Port int
+    TLS  bool
+}
+func ParseConfig(path string) (Config, error) { ... }
+```
+
+**Zig:**
+```zig
+// Bad: positional tuple
+fn parseEndpoint(raw: []const u8) struct { []const u8, u16 } { ... }
+
+// Better: named struct fields
+const Endpoint = struct {
+    host: []const u8,
+    port: u16,
+};
+fn parseEndpoint(raw: []const u8) Endpoint { ... }
+```
+
+**TypeScript:**
+```typescript
+// Bad: positional destructuring
+function useForm(): [string, (v: string) => void, () => void] { ... }
+const [value, setValue, reset] = useForm() // position-dependent
+
+// Better: return an object (reduces to CoN)
+function useForm(): { value: string; setValue: (v: string) => void; reset: () => void } { ... }
+const { value, setValue, reset } = useForm()
+```
+
+---
+
+### Connascence of Algorithm (CoA)
+
+Multiple components must independently implement the same algorithm. If the algorithm changes in one place, it must change everywhere — but there is no compiler or type system to enforce this.
+
+**Ruby:**
+```ruby
+# Writer and reader must agree on serialization format
+class CacheWriter
+  def write(key, data)
+    Redis.set(key, Marshal.dump(data))
+  end
+end
+
+class CacheReader
+  def read(key)
+    Marshal.load(Redis.get(key))  # must use same serialization
+  end
+end
+```
+
+**Go:**
+```go
+// Client and server must agree on HMAC algorithm
+func signRequest(body []byte, secret []byte) string {
+    mac := hmac.New(sha256.New, secret)
+    mac.Write(body)
+    return hex.EncodeToString(mac.Sum(nil))
+}
+
+func verifyRequest(body []byte, secret []byte, signature string) bool {
+    expected := signRequest(body, secret) // shares the algorithm
+    return hmac.Equal([]byte(expected), []byte(signature))
+}
+```
+
+**Zig:**
+```zig
+// Encoder and decoder must agree on byte order
+fn encode(value: u32, buf: []u8) void {
+    std.mem.writeInt(u32, buf[0..4], value, .big);
+}
+
+fn decode(buf: []const u8) u32 {
+    return std.mem.readInt(u32, buf[0..4], .big); // must match .big
+}
+```
+
+**TypeScript:**
+```typescript
+// Frontend and backend must agree on token format
+function generateToken(userId: string, secret: string): string {
+  return btoa(JSON.stringify({ sub: userId, iat: Date.now() }))
+}
+
+function parseToken(token: string): { sub: string; iat: number } {
+  return JSON.parse(atob(token))  // must match encoding scheme
+}
+```
+
+---
+
+## Dynamic Connascence Types
+
+Dynamic connascences are only apparent at runtime. They are harder to reason about and harder to refactor than static forms.
+
+### Connascence of Execution (CoE)
+
+The order of execution of multiple components is important. Calling operations out of sequence produces incorrect behavior.
+
+**Ruby:**
+```ruby
+email = Mail.new
+email.to = "user@example.com"
+email.subject = "Hello"
+email.deliver!
+# email.body = "Oops"  # too late — already sent
+```
+
+**Go:**
+```go
+srv := &http.Server{Addr: ":8080"}
+// Must register handlers BEFORE calling ListenAndServe
+http.HandleFunc("/health", healthHandler)
+srv.ListenAndServe() // blocks — anything after this won't register
+```
+
+**Zig:**
+```zig
+var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+defer _ = gpa.deinit();  // must deinit after all allocations freed
+const allocator = gpa.allocator();
+// If you deinit the GPA before freeing allocated memory, you leak
+```
+
+**TypeScript:**
+```typescript
+const app = express()
+app.use(authMiddleware)    // must come before routes
+app.get("/api/data", handler)
+app.listen(3000)           // must come after route registration
+```
+
+---
+
+### Connascence of Timing (CoTm)
+
+The timing of execution matters — not just order, but when operations happen relative to each other. Race conditions are the canonical example.
+
+**Ruby:**
+```ruby
+# Two threads updating a shared counter without synchronization
+counter = 0
+threads = 10.times.map do
+  Thread.new { 1000.times { counter += 1 } }  # race condition
+end
+threads.each(&:join)
+# counter may not be 10_000
+```
+
+**Go:**
+```go
+// Classic race: two goroutines, no synchronization
+var balance int64
+go func() { balance += 100 }()
+go func() { balance -= 50 }()
+// Result depends on timing — use atomic or mutex
+```
+
+**Zig:**
+```zig
+// Threads sharing mutable state without synchronization
+var shared: u64 = 0;
+// Two threads incrementing `shared` without a mutex
+// Result depends on scheduling — classic CoTm
+```
+
+**TypeScript:**
+```typescript
+// Race between two async operations writing to the same resource
+let cache: Record<string, string> = {}
+async function refresh(key: string) {
+  const value = await fetchRemote(key)  // timing-dependent
+  cache[key] = value                     // last write wins
+}
+// Two concurrent refresh() calls for the same key = race condition
+```
+
+---
+
+### Connascence of Value (CoV)
+
+Multiple values must change together to maintain correctness. The values are semantically linked but nothing in the system enforces their coordination.
+
+**Ruby:**
+```ruby
+# Rectangle invariant: opposite corners must be consistent
+class Rectangle
+  attr_accessor :x1, :y1, :x2, :y2
+  # Changing x1 without updating x2 can violate width constraints
+end
+```
+
+**Go:**
+```go
+// Pagination: offset and limit must be coordinated
+type Page struct {
+    Offset int  // if Offset changes, Limit may need to as well
+    Limit  int
+    Total  int  // must reflect actual count
+}
+```
+
+**Zig:**
+```zig
+// Slice and length must stay in sync
+const Buffer = struct {
+    data: [*]u8,
+    len: usize,
+    cap: usize,
+    // len must never exceed cap; data must point to at least cap bytes
+};
+```
+
+**TypeScript:**
+```typescript
+// Form state: values and validation errors must correspond
+interface FormState {
+  values: Record<string, string>
+  errors: Record<string, string>  // keys must match `values` keys
+  touched: Set<string>            // members must be valid field names
+}
+```
+
+---
+
+### Connascence of Identity (CoI)
+
+Multiple components must reference the same entity — not an equivalent one, but the identical instance. This is the strongest form: hardest to discover, hardest to refactor.
+
+**Ruby:**
+```ruby
+# Two objects must share the exact same logger instance (not a copy)
+class OrderService
+  def initialize(logger)
+    @logger = logger  # must be the SAME object as AuditService's logger
+  end
+end
+
+class AuditService
+  def initialize(logger)
+    @logger = logger  # same instance — not Logger.new with same config
+  end
+end
+```
+
+**Go:**
+```go
+// Both handlers must reference the same *sql.DB connection pool
+func NewOrderHandler(db *sql.DB) *OrderHandler { return &OrderHandler{db: db} }
+func NewAuditHandler(db *sql.DB) *AuditHandler { return &AuditHandler{db: db} }
+// If they get different pools, transaction isolation breaks
+```
+
+**Zig:**
+```zig
+// Two subsystems must share the same allocator instance
+// (not just the same type — the same runtime state)
+var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+const allocator = gpa.allocator();
+// If subsystem A and B get different allocators, memory accounting diverges
+```
+
+**TypeScript:**
+```typescript
+// React context: consumers must reference the same context object
+const ThemeContext = createContext<Theme>(defaultTheme)
+// If two files import different context objects (even with identical types),
+// useContext(ThemeContext) returns the wrong value
+```
+
+---
+
+## Source
+
+Based on the connascence framework by Meilir Page-Jones, expanded by Jim Weirich. Reference: https://connascence.io/


### PR DESCRIPTION
## Background

### bnferguson says
Long ago I heard Jim Weirich talk about Connascence at a conference. It seemed like a really interesting lens through which to look at and talk about types of coupling, giving things names, degrees etc. Not unlike the ole Refactoring book's "code smells". But Connascence isn't super clear cut and mechanical, it's more of something that surfaces potential areas where you need to apply some judgement. A skill felt like a nice thing to create to help me adjust my eyes to these patterns as it were.

### Claude says
Adds a Claude Code skill that applies the connascence framework (Page-Jones/Weirich) to assess coupling in code during review, refactoring, and design work. Connascence provides a taxonomy of 9 coupling types ordered by strength, giving a precise vocabulary for why certain coupling is worse than others and what to do about it. The skill is focused on Ruby, Go, Zig, and TypeScript but is language-agnostic in its framework.

The skill includes:
- Full taxonomy reference with examples in all four languages
- A refactoring guide with concrete transformation patterns (stronger → weaker)
- An LSP-integrated analysis workflow for measuring degree and locality
- A structured reporting format for findings

## Approach

The skill is structured as three files:
- `SKILL.md` — defines when to trigger, the analysis workflow (scan strongest-to-weakest, measure with LSP, assess, suggest transformations), and a structured reporting format
- `references/taxonomy.md` — the full 9-type taxonomy with the three properties (strength, degree, locality), strength ordering, and idiomatic examples in Ruby, Go, Zig, and TypeScript
- `references/refactoring-guide.md` — concrete transformation patterns (CoM→CoN, CoP→CoN, CoA→single source of truth, etc.) with before/after code in all four languages, plus a boundary/strength heuristic table

The skill explicitly filters out noise (won't flag CoN everywhere, won't flag connascence internal to small functions) and is honest about the limits of static analysis for dynamic connascence types. It's designed as a judgment aid, not a mechanical checker.

## Reviewer notes

This is a new skill — no existing code is modified. The skill is triggered by mentions of "connascence", "coupling", or "dependencies between components", and during code review and refactoring work.

## Testing plan

- [x] Invoke `/connascence` on a real codebase and verify the analysis workflow produces structured, prioritized findings
- [x] Verify LSP measurement step works when an LSP is available and is gracefully skipped when not
- [x] Check that the skill filters noise appropriately (doesn't flag CoN everywhere, skips internal-to-function coupling)