### PR TITLE
Switch Claude Code install from Homebrew to official installer

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -19,9 +19,6 @@ brew "actionlint"   # github actions linter
 brew "uv"           # python package manager
 brew "rtk"          # llm token-saving proxy
 
-# AI
-cask "claude-code"  # anthropic cli
-
 # macOS casks
 if OS.mac?
   cask "ghostty"        # terminal

--- a/claude/install.sh
+++ b/claude/install.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+#
+# Install Claude Code via the official installer.
+# This runs as a topic installer during script/install.
+
+if ! command -v claude >/dev/null 2>&1; then
+  echo "  Installing Claude Code via official installer..."
+  curl -fsSL https://claude.ai/install.sh | bash
+else
+  echo "  Claude Code already installed, updating..."
+  claude update
+fi


### PR DESCRIPTION
## Background

The Brewfile installed Claude Code via the `claude-code` Homebrew cask. At some point the preference shifted to using the official installer (`claude.ai/install.sh`), but the cask remained in the Brewfile — so running `script/bootstrap` would reinstall it via Homebrew, resulting in a duplicate installation.

## Approach

- Remove the `claude-code` cask from the Brewfile
- Add `claude/install.sh` as a topic installer that uses the official installer for fresh installs and `claude update` for existing ones
- Installs to `~/.local/bin/claude` (the official installer's default location)

## Reviewer notes

The official installer manages its own versioned binaries under `~/.local/share/claude/` with a symlink in `~/.local/bin/`. This is a different location than Homebrew's `/opt/homebrew/bin/claude`, so `~/.local/bin` needs to be on `$PATH` (it typically is via the installer's shell integration).

## Testing plan

- [x] Uninstalled Homebrew cask, installed via official installer — `claude` resolves to `~/.local/bin/claude`
- [ ] Run `script/bootstrap` on a clean machine to verify the topic installer works end-to-end