### PR TITLE
Reduce sandbox bypasses with excludedCommands and audit improvements

### DIFF
--- a/bin/claude-audit-sandbox
+++ b/bin/claude-audit-sandbox
@@ -4,7 +4,8 @@
 # Usage:
 #   claude-audit-sandbox           # show all bypasses
 #   claude-audit-sandbox summary   # group by command prefix + count
-#   claude-audit-sandbox suggest   # suggest sandbox config changes
+#   claude-audit-sandbox suggest   # suggest sandbox config as JSON
+#   claude-audit-sandbox reset     # clear the log for a fresh baseline
 
 LOG_FILE="$HOME/.claude/audit/sandbox-bypasses.jsonl"
 
@@ -17,6 +18,15 @@ fi
 COUNT=$(wc -l < "$LOG_FILE" | tr -d ' ')
 
 case "${1:-all}" in
+  reset)
+    if : > "$LOG_FILE" 2>/dev/null; then
+      echo "Audit log cleared."
+    else
+      echo "Failed to clear $LOG_FILE — check write permissions." >&2
+      exit 1
+    fi
+    exit 0
+    ;;
   all)
     echo "=== Sandbox Bypasses ($COUNT total) ==="
     echo ""
@@ -45,11 +55,6 @@ case "${1:-all}" in
       | grep -oE 'https?://[^/]+' \
       | sed 's|https\?://||' \
       | sort -u)
-    if [ -n "$DOMAINS" ]; then
-      echo "Network — add to sandbox.network.allowedDomains:"
-      echo "$DOMAINS" | while read -r d; do echo "  \"$d\""; done
-      echo ""
-    fi
 
     # Detect filesystem write patterns
     WRITE_PATHS=$(jq -r '.command | split("\n")[0]' "$LOG_FILE" \
@@ -57,29 +62,49 @@ case "${1:-all}" in
       | grep -oE '/[^[:space:];&|]+' \
       | xargs -I{} dirname {} 2>/dev/null \
       | sort -u)
-    if [ -n "$WRITE_PATHS" ]; then
-      echo "Filesystem — add to sandbox.filesystem.allowWrite:"
-      echo "$WRITE_PATHS" | while read -r p; do echo "  \"$p\""; done
-      echo ""
-    fi
 
-    # Detect commands that might be candidates for excludedCommands
+    # Detect commands that might be candidates for excludedCommands (>=3 occurrences)
     CMDS=$(jq -r '.command | split("\n")[0] | split(" ")[0]' "$LOG_FILE" \
       | sort | uniq -c | sort -rn \
       | awk '$1 >= 3 {print $2}')
-    if [ -n "$CMDS" ]; then
-      echo "Frequent bypassers — consider adding to sandbox.excludedCommands:"
-      echo "$CMDS" | while read -r c; do echo "  \"$c\""; done
-      echo ""
-    fi
 
     if [ -z "$DOMAINS" ] && [ -z "$WRITE_PATHS" ] && [ -z "$CMDS" ]; then
       echo "No clear patterns detected yet. Run 'summary' to see raw counts."
+      exit 0
     fi
+
+    # Build JSON snippet
+    echo "Merge into settings.json under \"sandbox\":"
+    echo ""
+    echo "{"
+
+    if [ -n "$CMDS" ]; then
+      echo "  \"excludedCommands\": ["
+      echo "$CMDS" | awk '{printf "    \"%s *\"", $0; if (NR < TOTAL) printf ","; printf "\n"}' TOTAL="$(echo "$CMDS" | wc -l | tr -d ' ')"
+      echo "  ],"
+    fi
+
+    if [ -n "$DOMAINS" ]; then
+      echo "  \"network\": {"
+      echo "    \"allowedDomains\": ["
+      echo "$DOMAINS" | awk '{printf "      \"%s\"", $0; if (NR < TOTAL) printf ","; printf "\n"}' TOTAL="$(echo "$DOMAINS" | wc -l | tr -d ' ')"
+      echo "    ]"
+      echo "  },"
+    fi
+
+    if [ -n "$WRITE_PATHS" ]; then
+      echo "  \"filesystem\": {"
+      echo "    \"allowWrite\": ["
+      echo "$WRITE_PATHS" | awk '{printf "      \"%s\"", $0; if (NR < TOTAL) printf ","; printf "\n"}' TOTAL="$(echo "$WRITE_PATHS" | wc -l | tr -d ' ')"
+      echo "    ]"
+      echo "  },"
+    fi
+
+    echo "}"
     ;;
 
   *)
-    echo "Usage: $0 [all|summary|suggest]"
+    echo "Usage: $0 [all|summary|suggest|reset]"
     exit 1
     ;;
 esac

--- a/claude/config/settings.json
+++ b/claude/config/settings.json
@@ -46,6 +46,7 @@
       "Bash(bin/rubocop:*)",
       "Bash(bin/brakeman:*)",
       "Bash(ruby:*)",
+      "Bash(mise:*)",
       "Bash(pnpm:*)",
       "Bash(node:*)",
       "Bash(ls:*)",
@@ -266,6 +267,12 @@
     }
   },
   "sandbox": {
+    "excludedCommands": [
+      "gh *",
+      "git push *",
+      "git fetch *",
+      "mise *"
+    ],
     "filesystem": {
       "allowWrite": [
         "/tmp",

--- a/claude/config/settings.json
+++ b/claude/config/settings.json
@@ -278,7 +278,8 @@
         "/tmp",
         "/private/tmp",
         "/private/var/folders",
-        "~/.cache"
+        "~/.cache",
+        "~/.claude/audit"
       ],
       "allowRead": [
         "~/.config/gh"


### PR DESCRIPTION
## Background
After running the sandbox bypass audit for a day, 75 bypasses showed that `gh`, `git push/fetch`, and `mise` consistently fail inside the macOS sandbox due to Mach IPC blocking TLS. Rather than living with `dangerouslyDisableSandbox` noise, we use the `excludedCommands` setting to run them outside the sandbox directly.

## Approach
- Add `sandbox.excludedCommands` for `gh`, `git push`, `git fetch`, and `mise` — these now run outside the sandbox automatically
- Add `Bash(mise:*)` to `permissions.allow` so it skips the permission prompt too
- Add `~/.claude/audit` to `sandbox.filesystem.allowWrite` so the audit log is manageable without bypassing the sandbox
- Improve the audit script: `reset` subcommand to clear the log, `suggest` now outputs a copy-pasteable JSON snippet for settings.json

## Reviewer notes
The `excludedCommands` setting was confirmed to exist via Claude Code docs. The `rtk`-prefixed commands (which wrap gh/git) may still bypass — worth watching in the next audit round and adding `"rtk *"` if needed.

## Testing plan
- [ ] Let it run and check `claude-audit-sandbox summary` — bypasses for gh/git push/mise should drop to zero
- [ ] Test `claude-audit-sandbox reset` clears the log
- [ ] Test `claude-audit-sandbox suggest` outputs valid JSON after new data accumulates