### PR TITLE
Explicitly scope prose style rules to PRs and comments

### DIFF
--- a/claude/config/CLAUDE.md
+++ b/claude/config/CLAUDE.md
@@ -63,8 +63,9 @@ The exception here is when you notice the code is getting messy or needs to be r
 - Zig: always invoke the `idiomatic-zig` and `zig-programming` skills before writing Zig code, then run the `zig-core-code-reviewer` agent after to verify. Additionally, invoke `zig-interop` when working on C interop (e.g., libc bindings, `@cImport`, linking C libraries).
 
 # Prose
-- When writing prose, follow [`style-guide.md`](style-guide.md) for voice and tone
-- Consult [`tropes.md`](tropes.md) for AI writing patterns to avoid
+- Follow [`style-guide.md`](style-guide.md) for voice and tone, and consult [`tropes.md`](tropes.md) for AI writing patterns to avoid
+- **This applies to all prose output**, not just long-form writing. PR descriptions, PR review comments, issue comments, Slack messages, commit messages, and any other text written on Brandon's behalf should follow the style guide and avoid the tropes
+- When drafting PR descriptions specifically: write in Brandon's voice, be direct and specific about what changed and why, skip the filler transitions and false profundity
 
 ## Code Search
 

--- a/claude/config/skills/pr/SKILL.md
+++ b/claude/config/skills/pr/SKILL.md
@@ -42,7 +42,7 @@ Create a draft pull request with an interview process that captures both the ass
 
 4. **Gauge the scope.** Look at what changed. If the PR is trivial (typo fix, version bump, single-line config change, etc.), propose skipping the interview: "This looks straightforward — here's what I'd put up. Want to go through the full interview, or is this good to go?" Let the user decide. For anything non-trivial, proceed with the interview.
 
-5. **Draft a PR title and all sections.** The title should be short (under 72 chars), imperative mood, and scoped to what changed (e.g., "Fix race condition in worker pool shutdown", "Add duti for default editor file associations"). Prepare drafts for each section from the template (or the defaults).
+5. **Draft a PR title and all sections.** The title should be short (under 72 chars), imperative mood, and scoped to what changed (e.g., "Fix race condition in worker pool shutdown", "Add duti for default editor file associations"). Prepare drafts for each section from the template (or the defaults). Follow the prose rules from `style-guide.md` and `tropes.md` — write in the user's voice, be direct and specific, avoid AI writing patterns.
 
 6. **Interview section by section.** For each section, present your draft and then ask the user for their take. Go through them one at a time. Default interview prompts (adapt to match template section names):
 


### PR DESCRIPTION
## Background
The style guide and tropes files existed but CLAUDE.md only said "when writing prose" — vague enough that the rules got ignored when drafting PR descriptions, issue comments, and other output written on Brandon's behalf. The `/pr` skill had no reference to them at all.

## Approach
Two changes. CLAUDE.md's Prose section now explicitly lists the contexts where the rules apply (PR descriptions, review comments, issue comments, Slack messages, commit messages). The `/pr` skill's drafting step (step 5) now references the style guide and tropes directly.

## Reviewer notes
The CLAUDE.md change is the important one — it applies globally regardless of which `/pr` skill is active (work projects override with their own). The skill change reinforces it for personal repos.

## Testing plan
Config-only change. Verify the instructions read clearly and the style guide / tropes references resolve correctly.