### PR TITLE
Fix skill descriptions and add skills-janitor plugin

### DIFF
--- a/claude/config/settings.json
+++ b/claude/config/settings.json
@@ -235,7 +235,8 @@
     "testing-handbook-skills@trailofbits": true,
     "slack@claude-plugins-official": true,
     "zls-lsp@zig-skills": true,
-    "clangd-lsp@claude-plugins-official": true
+    "clangd-lsp@claude-plugins-official": true,
+    "skills-janitor@skills-janitor": true
   },
   "extraKnownMarketplaces": {
     "ruby-skills": {
@@ -255,15 +256,15 @@
         "source": "github",
         "repo": "bnferguson/zig-skills"
       }
+    },
+    "skills-janitor": {
+      "source": {
+        "source": "github",
+        "repo": "khendzel/skills-janitor"
+      }
     }
   },
   "sandbox": {
-    "excludedCommands": [
-      "gh *",
-      "git push *",
-      "git fetch *",
-      "mise *"
-    ],
     "filesystem": {
       "allowWrite": [
         "/tmp",
@@ -275,7 +276,13 @@
       "allowRead": [
         "~/.config/gh"
       ]
-    }
+    },
+    "excludedCommands": [
+      "gh *",
+      "git push *",
+      "git fetch *",
+      "mise *"
+    ]
   },
   "spinnerVerbs": {
     "mode": "replace",

--- a/claude/config/skills/connascence/SKILL.md
+++ b/claude/config/skills/connascence/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: connascence
-description: Assess coupling in code using the connascence taxonomy. Use when reviewing code for coupling issues, planning refactors, evaluating design decisions, or when the user mentions "connascence", "coupling", or asks about dependencies between components. Focused on Ruby, Go, Zig, and TypeScript but applicable to any language.
+description: "Assess coupling using the connascence taxonomy. Use when reviewing code for coupling issues, planning refactors, or when the user mentions 'connascence' or 'coupling'."
 ---
 
 # Connascence Analysis

--- a/claude/config/skills/create-prd/SKILL.md
+++ b/claude/config/skills/create-prd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-prd
-description: "Generating a Product Requirements Document (PRD)"
+description: "Generate a Product Requirements Document. Use when the user wants to create a PRD, define feature requirements, or plan a new feature."
 ---
 
 # Rule: Generating a Product Requirements Document (PRD)

--- a/claude/config/skills/create-tasks/SKILL.md
+++ b/claude/config/skills/create-tasks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-tasks
-description: "Generating a Task List from User Requirements"
+description: "Generate a task list from requirements. Use when the user wants to break down a feature into implementation steps or create a development plan."
 ---
 
 Rule: Generating a Task List from User Requirements

--- a/claude/config/skills/deep-research/skill.md
+++ b/claude/config/skills/deep-research/skill.md
@@ -1,6 +1,6 @@
 ---
 name: deep-research
-description: This skill should be used when users request comprehensive, in-depth research on a topic that requires detailed analysis similar to an academic journal or whitepaper. The skill conducts multi-phase research using web search and content analysis, employing high parallelism with multiple subagents, and produces a detailed markdown report with citations.
+description: "Multi-phase research producing detailed reports with citations. Use when the user requests comprehensive, in-depth research on a topic requiring analysis similar to a whitepaper."
 license: MIT
 ---
 

--- a/claude/config/skills/go-review/SKILL.md
+++ b/claude/config/skills/go-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: go-review
-description: "Perform a Go focused code review checking idioms, patterns, and best practices"
+description: "Go-focused code review checking idioms, patterns, and best practices. Use when reviewing Go code changes on the current branch or when the user asks for a Go code review."
 ---
 
 Perform a Go focused code review of changes on the current branch.

--- a/claude/config/skills/idiomatic-zig/SKILL.md
+++ b/claude/config/skills/idiomatic-zig/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: idiomatic-zig
-description: >
-  Production patterns for writing idiomatic, high-performance Zig. Derived from Ghostty
-  (terminal emulator) and TigerBeetle (distributed database) — two of the most serious Zig
-  codebases in production. Use this skill when writing Zig code that needs to be fast, safe,
-  and maintainable. Complements the zig-programming skill (which covers language syntax and API
-  reference) with battle-tested idioms for real-world systems.
+description: "Production patterns for idiomatic, high-performance Zig from Ghostty and TigerBeetle. Use when writing Zig code that needs to be fast, safe, and maintainable."
 ---
 
 # Idiomatic Zig: Production Patterns from Ghostty & TigerBeetle

--- a/claude/config/skills/pr/SKILL.md
+++ b/claude/config/skills/pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr
-description: "Opening a Pull Request with Interview"
+description: "Open a Pull Request with an interview process. Use when the user wants to create a PR, open a pull request, or ship changes to a branch."
 ---
 
 # Rule: Opening a Pull Request with Interview

--- a/claude/config/skills/sandi-metz-rules/SKILL.md
+++ b/claude/config/skills/sandi-metz-rules/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sandi-metz-rules
-description: This skill should be used when users request code review, refactoring, or code quality improvements for Ruby codebases. Apply Sandi Metz's four rules for writing maintainable object-oriented code - classes under 100 lines, methods under 5 lines, no more than 4 parameters, and controllers instantiate only one object. Use when users mention "Sandi Metz", "code quality", "refactoring", or when reviewing Ruby code for maintainability.
+description: "Apply Sandi Metz's four rules for maintainable Ruby code. Use when reviewing or refactoring Ruby code, or when the user mentions 'Sandi Metz', 'code quality', or 'refactoring'."
 ---
 
 # Sandi Metz Rules

--- a/claude/config/skills/vera/SKILL.md
+++ b/claude/config/skills/vera/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vera
-description: Semantic code search, regex pattern search, and symbol lookup across a local repository. Returns ranked markdown codeblocks with file path, line range, content, and optional symbol info. Use `vera search` for conceptual/behavioral queries (how a feature works, where logic lives, exploring unfamiliar code). Use `vera grep` for exact strings, regex patterns, imports, and TODOs. Use `vera references` to trace callers/callees. Use rg only for bulk find-and-replace or files outside the index.
+description: "Semantic code search, regex pattern search, and symbol lookup across a repository. Use when searching for code by behavior, tracing callers/callees, or exploring unfamiliar code."
 ---
 
 # Vera

--- a/claude/config/skills/webapp-testing/SKILL.md
+++ b/claude/config/skills/webapp-testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: webapp-testing
-description: Toolkit for interacting with and testing local web applications using Playwright. Supports verifying frontend functionality, debugging UI behavior, capturing browser screenshots, and viewing browser logs.
+description: "Test local web applications using Playwright. Use when verifying frontend functionality, debugging UI behavior, capturing browser screenshots, or viewing browser logs."
 license: Complete terms in LICENSE.txt
 ---
 

--- a/claude/config/skills/zig-async-skill/SKILL.md
+++ b/claude/config/skills/zig-async-skill/SKILL.md
@@ -1,9 +1,6 @@
 ---
-name: zig-async-io
-description: >
-  Zig 0.16.0 async I/O programming with the new std.Io interface. Covers async/concurrent
-  primitives, Future handling, cancellation patterns, and I/O implementation strategies.
-  Use when working with Zig 0.16.0+ async code, event loops, concurrent tasks, or non-blocking I/O.
+name: zig-async-skill
+description: "Zig 0.16.0 async I/O programming with the new std.Io interface. Use when working with Zig 0.16.0+ async code, event loops, concurrent tasks, or non-blocking I/O."
 ---
 
 # Zig Async I/O Skill (0.16.0+)

--- a/claude/config/skills/zig-interop/SKILL.md
+++ b/claude/config/skills/zig-interop/SKILL.md
@@ -1,13 +1,6 @@
 ---
 name: zig-interop
-description: >
-  This skill should be used when working on Zig FFI or cross-language
-  interoperability — wrapping C libraries, binding C++, exporting Zig
-  as C, bridging Zig with Rust/Swift/ObjC/Go/Ruby, configuring build.zig
-  for C compilation, or using comptime for FFI metaprogramming. Patterns
-  are extracted from production codebases (Bun, Ghostty, libxev,
-  TigerBeetle, Lightpanda). Targets Zig 0.15+. Complements
-  zig-programming (language fundamentals) and idiomatic-zig (style).
+description: "Zig FFI and cross-language interop from Bun, Ghostty, and TigerBeetle. Use when wrapping C libraries, binding C++, exporting Zig as C, or configuring build.zig for C compilation."
 ---
 
 # Zig Interop Skill

--- a/claude/config/skills/zig-programming/SKILL.md
+++ b/claude/config/skills/zig-programming/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: zig-programming
-description: >
-  Provides comprehensive Zig programming language expertise including syntax, standard library,
-  build system, memory management, error handling, and C interoperability. Use this skill when
-  working with Zig code, learning Zig concepts, debugging compilation errors, or building
-  Zig applications across multiple versions (0.2.0 through master).
+description: "Comprehensive Zig language expertise covering syntax, stdlib, build system, and error handling. Use when working with Zig code, debugging compilation errors, or building Zig applications."
 ---
 
 # Zig Programming Language Skill


### PR DESCRIPTION
## Background

Ran skills-janitor lint and found 14 warnings across skill descriptions — multi-line YAML that the linter couldn't parse, missing trigger conditions, overly long descriptions, and a name/folder mismatch. Fixed all of them and registered the skills-janitor plugin that surfaced the issues.

## Approach

Standardized all 13 skill SKILL.md frontmatter descriptions to single-line quoted strings under 200 chars with "Use when..." trigger conditions. Fixed zig-async-skill's name field to match its folder. Added skills-janitor plugin registration to settings.json.

## Testing plan

- Ran the linter before (14 warnings) and after (0 warnings)
- Skills still load and display correctly in the skill list