### PR TITLE
Fix stale doc references and note BTT arrow-key Fn quirk

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,4 +53,5 @@ Bootstrap uses **relative symlinks** (via perl `File::Spec->abs2rel`) so they wo
 - `zsh/zshrc.symlink` has an LM Studio PATH append at the bottom that was added outside the dotfiles pattern — don't duplicate this kind of thing
 - The `.cache/` directory holds generated files (like kubectl completions) — these are gitignored
 - BTT presets are not auto-synced; manual export/import is required after changes
+- BTT preset arrow-key bindings store an implicit Fn modifier (`BTTShortcutModifierKeys: 10354688` = Hyper+Fn) because Apple keyboards attach Fn to arrow keys at the hardware level. When documenting those shortcuts, write them as `Hyper+Up` etc. — not `Fn+Hyper+Up`.
 - `nvim/lazy-lock.json` tracks neovim plugin versions — changes here are from plugin updates

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Personal dotfiles, originally forked from [holman/dotfiles](https://github.com/h
 | Topic | What it does |
 |-------|-------------|
 | `bettertouchtool/` | BTT preset export/import scripts — run `export` and `import` manually |
-| `bin/` | Scripts added to `$PATH` — `tree-me`, `git-sync`, `git-promote`, etc. |
+| `bin/` | Scripts added to `$PATH` — `git-tree`, `git-sync`, `git-promote`, etc. |
+| `bun/` | Bun JS runtime completion + path setup |
 | `claude/` | Claude Code config — settings, skills, commands, agents |
 | `gh/` | GitHub CLI config |
 | `ghostty/` | Ghostty terminal config |
@@ -21,6 +22,7 @@ Personal dotfiles, originally forked from [holman/dotfiles](https://github.com/h
 | `ssh/` | SSH config |
 | `starship/` | Starship prompt config |
 | `system/` | PATH, EDITOR, ls aliases, keybindings |
+| `vera/` | Vera code-search tool installer |
 | `zed/` | Zed editor settings |
 | `zsh/` | Shell config, completion, prompt |
 
@@ -45,7 +47,7 @@ script/bootstrap
 
 ### dependencies
 
-Install these before running bootstrap, or let `dot` handle it on macOS:
+Install these before running bootstrap, or let `dots` handle it on macOS:
 
 - [starship](https://starship.rs) — `brew install starship` or `curl -sS https://starship.rs/install.sh | sh`
 - [mise](https://mise.jdx.dev) — `brew install mise` or `curl https://mise.run | sh`
@@ -57,7 +59,7 @@ Install these before running bootstrap, or let `dot` handle it on macOS:
 
 ## maintenance
 
-Run `dot` periodically to update homebrew and run installers. Use `dot -e` to open the dotfiles in your editor.
+Run `dots` periodically to update homebrew and run installers. Use `dots -e` to open the dotfiles in your editor.
 
 ## keyboard setup
 
@@ -102,10 +104,10 @@ The active BTT preset (`bttsettings_70697`) uses the Hyper key from Karabiner to
 
 | Shortcut | Action |
 |----------|--------|
-| Fn+Hyper+Up | Maximize window |
-| Fn+Hyper+Down | Restore previous window size |
-| Fn+Hyper+Left | Left half |
-| Fn+Hyper+Right | Right half |
+| Hyper+Up | Maximize window |
+| Hyper+Down | Restore previous window size |
+| Hyper+Left | Left half |
+| Hyper+Right | Right half |
 
 **Other:**
 


### PR DESCRIPTION
## Background

Three stale items in the README and a correction to the window-management shortcut table. While there, added a note to `CLAUDE.md` about the BTT preset's implicit Fn modifier on arrow keys so future doc passes don't get tripped up by it.

## Approach

README fixes:
- `tree-me` → `git-tree` (the actual bin is `git-tree`; `tree-me.zsh` just sources its shellenv)
- `dot` → `dots` (binary is `dots`, plural)
- Added missing topics `bun/` and `vera/` to the topic table
- Window-management shortcuts corrected from `Fn+Hyper+<arrow>` to `Hyper+<arrow>` — matches what you actually press

CLAUDE.md:
- Added a "Things to Watch Out For" bullet explaining that `.bttpreset` files store `BTTShortcutModifierKeys: 10354688` (Hyper+Fn) on arrow-key bindings because Apple attaches Fn to arrow keys at the hardware level. Documenting raw from the preset would lead you to the wrong shortcut.

## Reviewer notes

Left the Karabiner section's `Fn+Hyper+H/J/K/L → Home/PgDn/PgUp/End` untouched since that's a separate Karabiner rule and wasn't part of the correction. If that's also wrong, say the word and I'll follow up.

## Testing plan

- [ ] Skim the rendered README on GitHub to confirm the topic table and keyboard tables look right
- [ ] Confirm Hyper+Up/Down/Left/Right actually do what the table claims (maximize / restore / left half / right half)