### PR TITLE
Add claude-review command for isolated PR reviews

### DIFF
--- a/bin/claude-review
+++ b/bin/claude-review
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Start a Claude session to review a PR in an isolated worktree.
+# Start a Claude session in an isolated worktree for a PR or branch.
 #
 # Usage:
 #
@@ -135,15 +135,7 @@ case "$1" in
     fi
 
     cd "$WT_PATH"
-    echo "Starting Claude in $WT_PATH"
-
-    if [ "$IS_PR" = true ]; then
-      echo "Review PR #$TARGET"
-      claude --prompt "Review PR #$TARGET. Start by running \`gh pr view $TARGET\` and \`gh pr diff $TARGET\` to understand the changes, then do a thorough code review." "$@"
-    else
-      echo "Review branch $TARGET"
-      claude --prompt "Review the branch '$TARGET'. Start by examining the commits and diff against the base branch to understand the changes, then do a thorough code review." "$@"
-    fi
+    claude "$@"
 
     # Offer cleanup when claude exits
     echo ""

--- a/bin/claude-review
+++ b/bin/claude-review
@@ -135,7 +135,7 @@ case "$1" in
     fi
 
     cd "$WT_PATH"
-    claude "$@"
+    claude --dangerously-skip-permissions "$@"
 
     # Offer cleanup when claude exits
     echo ""

--- a/bin/claude-review
+++ b/bin/claude-review
@@ -1,0 +1,158 @@
+#!/bin/sh
+#
+# Start a Claude session to review a PR in an isolated worktree.
+#
+# Usage:
+#
+#   claude-review 123                    # review PR #123
+#   claude-review feature-branch         # review a branch by name
+#   claude-review 123 --hierarchical     # pass extra args to claude
+#   claude-review list                   # show active review worktrees
+#   claude-review clean 123             # remove worktree for PR #123
+#   claude-review clean feature-branch  # remove worktree for a branch
+#   claude-review clean                 # remove all review worktrees
+#
+# The worktree is created at <repo>/.claude/worktrees/<name>.
+# When claude exits, you're prompted to clean up the worktree.
+
+set -e
+
+usage() {
+  echo "claude-review — PR review in an isolated worktree"
+  echo ""
+  echo "Usage:"
+  echo "  claude-review <pr-number|branch> [claude args...]"
+  echo "  claude-review list"
+  echo "  claude-review clean [pr-number|branch]"
+  echo ""
+  echo "Examples:"
+  echo "  claude-review 42"
+  echo "  claude-review feature-branch"
+  echo "  claude-review clean 42"
+  exit 1
+}
+
+if [ $# -eq 0 ]; then
+  usage
+fi
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  echo "Not in a git repository." >&2
+  exit 1
+}
+WORKTREE_DIR="$REPO_ROOT/.claude/worktrees"
+
+# Sanitize a ref for use as a directory name (slashes become dashes)
+sanitize_name() {
+  echo "$1" | sed 's|/|-|g'
+}
+
+case "$1" in
+  list)
+    if [ ! -d "$WORKTREE_DIR" ] || [ -z "$(ls -A "$WORKTREE_DIR" 2>/dev/null)" ]; then
+      echo "No active review worktrees."
+      exit 0
+    fi
+    echo "Active review worktrees:"
+    for d in "$WORKTREE_DIR"/*/; do
+      [ -d "$d" ] || continue
+      name=$(basename "$d")
+      branch=$(git -C "$d" branch --show-current 2>/dev/null || echo "detached")
+      echo "  $name ($branch)"
+    done
+    exit 0
+    ;;
+
+  clean)
+    if [ -n "$2" ]; then
+      # Try both the raw name and pr- prefixed name for numbers
+      target=$(sanitize_name "$2")
+      wt="$WORKTREE_DIR/$target"
+      if [ ! -d "$wt" ]; then
+        wt="$WORKTREE_DIR/pr-$target"
+      fi
+      if [ -d "$wt" ]; then
+        git worktree remove "$wt"
+        echo "Removed worktree $(basename "$wt")."
+      else
+        echo "No worktree found for '$2'." >&2
+        exit 1
+      fi
+    else
+      found=0
+      for d in "$WORKTREE_DIR"/*/; do
+        [ -d "$d" ] || continue
+        git worktree remove "$d"
+        found=1
+        echo "Removed $(basename "$d")"
+      done
+      if [ "$found" -eq 0 ]; then
+        echo "No review worktrees to clean up."
+      fi
+      rmdir "$WORKTREE_DIR" 2>/dev/null || true
+    fi
+    exit 0
+    ;;
+
+  -h|--help|help)
+    usage
+    ;;
+
+  *)
+    TARGET="$1"
+    shift
+
+    # Determine if this is a PR number or a branch name
+    case "$TARGET" in
+      *[!0-9]*)
+        # Branch name
+        IS_PR=false
+        WT_NAME=$(sanitize_name "$TARGET")
+        WT_PATH="$WORKTREE_DIR/$WT_NAME"
+        ;;
+      *)
+        # PR number
+        IS_PR=true
+        WT_NAME="pr-$TARGET"
+        WT_PATH="$WORKTREE_DIR/$WT_NAME"
+        ;;
+    esac
+
+    if [ -d "$WT_PATH" ]; then
+      echo "Worktree already exists at $WT_PATH"
+      echo "Resuming review..."
+    else
+      mkdir -p "$WORKTREE_DIR"
+
+      if [ "$IS_PR" = true ]; then
+        DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||') || DEFAULT_BRANCH="main"
+        git worktree add "$WT_PATH" "$DEFAULT_BRANCH" --detach
+        gh -C "$WT_PATH" pr checkout "$TARGET"
+      else
+        git fetch origin "$TARGET" 2>/dev/null || true
+        git worktree add "$WT_PATH" "origin/$TARGET"
+      fi
+    fi
+
+    cd "$WT_PATH"
+    echo "Starting Claude in $WT_PATH"
+
+    if [ "$IS_PR" = true ]; then
+      echo "Review PR #$TARGET"
+      claude --prompt "Review PR #$TARGET. Start by running \`gh pr view $TARGET\` and \`gh pr diff $TARGET\` to understand the changes, then do a thorough code review." "$@"
+    else
+      echo "Review branch $TARGET"
+      claude --prompt "Review the branch '$TARGET'. Start by examining the commits and diff against the base branch to understand the changes, then do a thorough code review." "$@"
+    fi
+
+    # Offer cleanup when claude exits
+    echo ""
+    printf "Remove review worktree? [Y/n] "
+    read -r answer
+    case "$answer" in
+      [nN]*) echo "Worktree kept at $WT_PATH. Run 'claude-review clean $WT_NAME' later." ;;
+      *) git worktree remove "$WT_PATH"
+         echo "Worktree removed." ;;
+    esac
+    ;;
+esac


### PR DESCRIPTION
## Background

### bnferguson says
Really enjoyed using Conductor for PR reviews, but lefthook plus sandboxing basically broke using it. This is an easy command to spin up a worktree fast from an existing branch or PR so I can review using my own tooling.

### Claude says
Reviewing PRs on your working branch is disruptive — it means stashing, switching, and losing your place. This adds a `claude-review` command that creates a git worktree under `.claude/worktrees/`, checks out the PR or branch, and launches Claude there. Review context stays isolated from in-flight work and the worktree is disposable.

## Approach

### bnferguson says
Using `--dangerously-skip-permissions` because my default setup has sandboxing and this is how I end up rolling with things these days. Makes reviews and edits lower friction.

### Claude says
Single POSIX `sh` script at `bin/claude-review`. Worktrees live at `.claude/worktrees/<name>` — `pr-<N>` for PR numbers (checked out via `gh pr checkout` from a detached default branch), sanitized branch names otherwise. Three modes: `claude-review <pr|branch>` creates or resumes a worktree and launches `claude --dangerously-skip-permissions` inside it; `list` shows active worktrees; `clean [target]` removes one or all. Extra args pass through to `claude`. On exit, prompts to remove the worktree.

## Reviewer notes

- POSIX `sh`, not bash — should run under any `/bin/sh`.
- Worktrees live under `.claude/worktrees/` inside the repo being reviewed; make sure that path is gitignored wherever this gets used or it'll show up as untracked.
- PR checkouts start from the default branch detached, then `gh pr checkout` switches to the PR branch. Branch checkouts fetch `origin/<branch>` first.
- `--dangerously-skip-permissions` is the default since sandboxing is the outer safety layer.

## Testing plan

- `claude-review <pr-number>` creates a worktree at `.claude/worktrees/pr-<N>` and launches claude
- `claude-review <branch>` creates a worktree at `.claude/worktrees/<sanitized-branch>`
- `claude-review list` shows active worktrees
- `claude-review clean <target>` removes a specific worktree
- `claude-review clean` (no target) removes all review worktrees
- Exiting claude prompts for cleanup (Y/n)