### PR TITLE
Fix detached HEAD when claude-review checks out a branch

### DIFF
--- a/bin/claude-review
+++ b/bin/claude-review
@@ -130,7 +130,13 @@ case "$1" in
         gh -C "$WT_PATH" pr checkout "$TARGET"
       else
         git fetch origin "$TARGET" 2>/dev/null || true
-        git worktree add "$WT_PATH" "origin/$TARGET"
+        # Attach to a local branch so Claude's branch/PR tooling works.
+        # Reuse an existing local branch if present; otherwise create one tracking origin.
+        if git show-ref --verify --quiet "refs/heads/$TARGET"; then
+          git worktree add "$WT_PATH" "$TARGET"
+        else
+          git worktree add -b "$TARGET" "$WT_PATH" "origin/$TARGET"
+        fi
       fi
     fi
 


### PR DESCRIPTION
## Background

`claude-review <branch>` was leaving the worktree in a detached HEAD state because `git worktree add <path> origin/<branch>` resolves the remote-tracking ref to a commit rather than attaching to a local branch. That broke Claude's branch and PR handling inside the review session.

## Approach

Attach to a local branch when setting up the worktree: reuse an existing local branch if one exists, otherwise create a new local branch tracking `origin/<branch>`. The PR path is untouched — `gh pr checkout` already handles branch attachment.