### PR TITLE
Tune Ghostty and Hyprland for mac muscle memory

### DIFF
--- a/ghostty/config
+++ b/ghostty/config
@@ -56,3 +56,21 @@ theme = Gruvbox Dark Hard
 # # Just for example:
 # resize-overlay-duration = 4s 200ms
 keybind = shift+enter=text:\x1b\r
+
+# Mac-style bindings — Alt mirrors Cmd from macOS Ghostty
+keybind = alt+t=new_tab
+keybind = alt+n=new_window
+keybind = alt+shift+left_bracket=previous_tab
+keybind = alt+shift+right_bracket=next_tab
+keybind = alt+d=new_split:right
+keybind = alt+shift+d=new_split:down
+keybind = alt+w=close_surface
+keybind = alt+shift+w=close_window
+keybind = alt+enter=toggle_split_zoom
+keybind = alt+equal=equalize_splits
+keybind = alt+left_bracket=goto_split:previous
+keybind = alt+right_bracket=goto_split:next
+keybind = alt+shift+up=resize_split:up,10
+keybind = alt+shift+down=resize_split:down,10
+keybind = alt+shift+left=resize_split:left,10
+keybind = alt+shift+right=resize_split:right,10

--- a/ghostty/config
+++ b/ghostty/config
@@ -57,20 +57,8 @@ theme = Gruvbox Dark Hard
 # resize-overlay-duration = 4s 200ms
 keybind = shift+enter=text:\x1b\r
 
-# Mac-style bindings — Alt mirrors Cmd from macOS Ghostty
-keybind = alt+t=new_tab
-keybind = alt+n=new_window
-keybind = alt+shift+left_bracket=previous_tab
-keybind = alt+shift+right_bracket=next_tab
-keybind = alt+d=new_split:right
-keybind = alt+shift+d=new_split:down
-keybind = alt+w=close_surface
-keybind = alt+shift+w=close_window
-keybind = alt+enter=toggle_split_zoom
-keybind = alt+equal=equalize_splits
-keybind = alt+left_bracket=goto_split:previous
-keybind = alt+right_bracket=goto_split:next
-keybind = alt+shift+up=resize_split:up,10
-keybind = alt+shift+down=resize_split:down,10
-keybind = alt+shift+left=resize_split:left,10
-keybind = alt+shift+right=resize_split:right,10
+# Per-OS overrides. The ? prefix makes each optional — bootstrap only
+# symlinks the matching file into ~/.config/ghostty/, so the other one
+# silently no-ops.
+config-file = ?config.linux
+config-file = ?config.macos

--- a/ghostty/config.linux
+++ b/ghostty/config.linux
@@ -1,0 +1,24 @@
+# Linux-only Ghostty bindings.
+#
+# Mirrors macOS Ghostty muscle memory by mapping Alt to what Cmd does on
+# mac: tab/window create, split create, navigate, resize, zoom, equalize.
+# On macOS these are not needed — Ghostty's defaults already use Cmd.
+#
+# Trade-off: Alt+D shadows readline delete-word-forward in shells.
+
+keybind = alt+t=new_tab
+keybind = alt+n=new_window
+keybind = alt+shift+left_bracket=previous_tab
+keybind = alt+shift+right_bracket=next_tab
+keybind = alt+d=new_split:right
+keybind = alt+shift+d=new_split:down
+keybind = alt+w=close_surface
+keybind = alt+shift+w=close_window
+keybind = alt+enter=toggle_split_zoom
+keybind = alt+equal=equalize_splits
+keybind = alt+left_bracket=goto_split:previous
+keybind = alt+right_bracket=goto_split:next
+keybind = alt+shift+up=resize_split:up,10
+keybind = alt+shift+down=resize_split:down,10
+keybind = alt+shift+left=resize_split:left,10
+keybind = alt+shift+right=resize_split:right,10

--- a/ghostty/config.macos
+++ b/ghostty/config.macos
@@ -1,0 +1,4 @@
+# macOS-only Ghostty overrides.
+#
+# Ghostty's macOS defaults already use Cmd for tabs/windows/splits, so most
+# things work out of the box. Add mac-specific tweaks here as they come up.

--- a/hyprland/bindings.conf
+++ b/hyprland/bindings.conf
@@ -15,7 +15,7 @@ bindd = $hyper, 5, Screenshot menu, exec, omarchy-capture-screenshot smart
 
 # App launchers
 bindd = $hyper, Q, Email, exec, omarchy-launch-webapp "https://app.hey.com"
-bindd = $hyper, W, Terminal (right half), exec, uwsm-app -- xdg-terminal-exec
+bindd = $hyper, W, Terminal (focus or launch), exec, omarchy-launch-or-focus ^com\.mitchellh\.ghostty$ "uwsm-app -- xdg-terminal-exec"
 bindd = $hyper, E, Editor, exec, omarchy-launch-editor
 bindd = $hyper, R, Browser, exec, omarchy-launch-browser
 bindd = $hyper, S, Spotify, exec, omarchy-launch-or-focus spotify

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -171,6 +171,12 @@ install_larger_paths () {
 
   mkdir -p "$HOME/.config/ghostty"
   link_file "$DOTFILES_ROOT/ghostty/config" "$HOME/.config/ghostty/config"
+  if [ "$(uname -s)" == "Darwin" ]; then
+    link_file "$DOTFILES_ROOT/ghostty/config.macos" "$HOME/.config/ghostty/config.macos"
+  fi
+  if [ "$(uname -s)" == "Linux" ]; then
+    link_file "$DOTFILES_ROOT/ghostty/config.linux" "$HOME/.config/ghostty/config.linux"
+  fi
 
   mkdir -p "$HOME/.ssh"
   chmod 700 "$HOME/.ssh"


### PR DESCRIPTION
## Background
Coming from macOS where Ghostty natively binds Cmd+D/Cmd+T/Cmd+W etc., the Linux defaults (Ctrl+Shift+T, Ctrl+Shift+O, …) don't match the muscle memory. Hyper+W on Hyprland always spawned a new terminal, but other singleton apps in the same config (Spotify, Signal, Obsidian) already use `omarchy-launch-or-focus` to focus an existing window — Ghostty was the odd one out.

## Approach
- Added Alt-modifier bindings to Ghostty that mirror its macOS Cmd defaults: `Alt+T` new tab, `Alt+N` new window, `Alt+D` split right, `Alt+Shift+D` split down, `Alt+W` close split, `Alt+Shift+W` close window, `Alt+Enter` toggle zoom, `Alt+=` equalize, `Alt+[/]` cycle splits, `Alt+Shift+[/]` cycle tabs, `Alt+Shift+arrows` resize split.
- Split the config by OS. `ghostty/config` holds shared settings and includes `config-file = ?config.linux` and `?config.macos`. The Alt bindings live in `ghostty/config.linux`; `ghostty/config.macos` is a placeholder. `script/bootstrap` symlinks only the matching file into `~/.config/ghostty/`, and the `?` prefix on the include silently skips the absent one.
- Changed `Hyper+W` to `omarchy-launch-or-focus ^com\.mitchellh\.ghostty$` so it focuses an existing Ghostty if one's open and only spawns a new window otherwise. `Hyper+G` keeps its unconditional spawn for when a fresh window is wanted.

## Reviewer notes
- `Alt+D` shadows readline's `delete-word-forward` (M-d) in any shell running inside Ghostty — main trade-off of mirroring Cmd→Alt.
- Ghostty's `?` prefix on `config-file` is its optional-include syntax: missing files are silently skipped without error.
- Linux symlink is already in place on this machine (created manually during verification); the bootstrap change is for future installs / new machines.

## Testing plan
- [x] `ghostty +validate-config` → exit 0.
- [x] `ghostty +list-keybinds | grep '^keybind = alt+'` confirms the new bindings are loaded.
- [ ] Reload Ghostty (`Ctrl+Shift+,`) and try `Alt+D`, `Alt+T`, `Alt+W` interactively.
- [ ] `hyprctl reload` then `Hyper+W` focuses existing Ghostty, or launches one if none running.