### PR TITLE
Fix wrong $SHELL on Linux and consolidate shell config

### DIFF
--- a/environment.d/shell.conf
+++ b/environment.d/shell.conf
@@ -1,0 +1,6 @@
+# systemd-user reads this at session start and propagates SHELL to every
+# service it launches (Hyprland → Ghostty, VSCode terminals, etc.).
+#
+# Needed on Arch + SDDM autologin: /etc/passwd has zsh as the login shell,
+# but SDDM spawns user services via /bin/sh so SHELL ends up as bash.
+SHELL=/usr/bin/zsh

--- a/environment.d/shell.conf
+++ b/environment.d/shell.conf
@@ -1,6 +1,1 @@
-# systemd-user reads this at session start and propagates SHELL to every
-# service it launches (Hyprland → Ghostty, VSCode terminals, etc.).
-#
-# Needed on Arch + SDDM autologin: /etc/passwd has zsh as the login shell,
-# but SDDM spawns user services via /bin/sh so SHELL ends up as bash.
-SHELL=/usr/bin/zsh
+../shell.env

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -205,6 +205,10 @@ install_larger_paths () {
       link_file "$DOTFILES_ROOT/hyprland/bindings.conf" "$HOME/.config/hypr/bindings.conf"
       link_file "$DOTFILES_ROOT/hyprland/input.conf" "$HOME/.config/hypr/input.conf"
     fi
+
+    # systemd-user environment overrides
+    mkdir -p "$HOME/.config/environment.d"
+    link_file "$DOTFILES_ROOT/environment.d/shell.conf" "$HOME/.config/environment.d/shell.conf"
   fi
 }
 

--- a/script/install
+++ b/script/install
@@ -35,22 +35,27 @@ elif command -v apt-get >/dev/null 2>&1; then
   echo "  Note: starship, mise, and gh need manual install on Ubuntu — see README"
 fi
 
-# Switch default shell to zsh if it isn't already
-if command -v zsh >/dev/null 2>&1; then
-  zsh_path="$(command -v zsh)"
-  if command -v getent >/dev/null 2>&1; then
-    current_shell="$(getent passwd "$USER" | cut -d: -f7)"
-  elif command -v dscl >/dev/null 2>&1; then
-    current_shell="$(dscl . -read "/Users/$USER" UserShell 2>/dev/null | awk '{print $2}')"
-  else
-    current_shell="$SHELL"
-  fi
-  if [ "$(basename "$current_shell")" != "zsh" ]; then
-    echo "› changing default shell to zsh ($zsh_path)"
-    if ! grep -qx "$zsh_path" /etc/shells; then
-      echo "$zsh_path" | sudo tee -a /etc/shells >/dev/null
+# Switch default shell to whatever shell.env declares, if it isn't already.
+# shell.env is the single source of truth for the shell path.
+if [ -f shell.env ]; then
+  desired_shell="$(. ./shell.env && echo "$SHELL")"
+  if [ -x "$desired_shell" ]; then
+    if command -v getent >/dev/null 2>&1; then
+      current_shell="$(getent passwd "$USER" | cut -d: -f7)"
+    elif command -v dscl >/dev/null 2>&1; then
+      current_shell="$(dscl . -read "/Users/$USER" UserShell 2>/dev/null | awk '{print $2}')"
+    else
+      current_shell="$SHELL"
     fi
-    chsh -s "$zsh_path"
+    if [ "$current_shell" != "$desired_shell" ]; then
+      echo "› changing default shell to $desired_shell"
+      if ! grep -qx "$desired_shell" /etc/shells; then
+        echo "$desired_shell" | sudo tee -a /etc/shells >/dev/null
+      fi
+      chsh -s "$desired_shell"
+    fi
+  else
+    echo "  Note: shell.env points to $desired_shell but it isn't executable; skipping chsh"
   fi
 fi
 

--- a/shell.env
+++ b/shell.env
@@ -1,0 +1,11 @@
+# Single source of truth for the user's default shell. Consumed by:
+#   - script/install (chsh during bootstrap)
+#   - ~/.config/environment.d/shell.conf (via symlink — propagates SHELL
+#     to every systemd-user service: Hyprland, Ghostty, etc.)
+#
+# Format is plain KEY=VALUE so both `bash source` and systemd's
+# environment.d parser accept it. Don't add `export` — systemd rejects it.
+#
+# Note: changing this is necessary but not sufficient to switch shells.
+# The `zsh/` topic directory and its *.zsh files still need to be ported.
+SHELL=/usr/bin/zsh


### PR DESCRIPTION
## Background
On Arch with SDDM autologin, `$SHELL` ended up as `/usr/bin/bash` even though `/etc/passwd` lists zsh as the login shell. SDDM spawns user services via `/bin/sh`, so the systemd-user manager captures `SHELL=bash` at session start and propagates it to everything it launches — Hyprland, Ghostty (bash prompts), VSCode terminals. While fixing that, the shell path was about to be defined in two places: `script/install` (hardcoded zsh for chsh) and the new `environment.d/shell.conf`. Consolidated into one source.

## Approach
- Added `environment.d/shell.conf` with `SHELL=/usr/bin/zsh`. systemd-user reads `~/.config/environment.d/*.conf` at session start and propagates entries to every user service. `script/bootstrap` symlinks it on Linux only.
- Hoisted the shell choice to a top-level `shell.env`. `environment.d/shell.conf` is now a relative symlink to it so systemd reads the same value, and `script/install` sources it for chsh — no more hardcoded "zsh" check. Switching shells (e.g., to fish) means editing one file (plus the bigger rewrite of `zsh/`-flavored config files, which is separate).

## Reviewer notes
- `shell.env` uses plain `KEY=VALUE` so both bash `source` and systemd's environment.d parser accept it. `export` is rejected by systemd, so it's intentionally absent.
- Takes effect for new sessions on next login. For the current session I ran `systemctl --user set-environment SHELL=/usr/bin/zsh` so new launches via uwsm-app pick it up without waiting.
- `fcitx.conf` already in `~/.config/environment.d/` is untouched — it's Omarchy default config, not a personal customization, so left out of the dotfiles.

## Testing plan
- [x] `systemctl --user show-environment | grep SHELL` → `/usr/bin/zsh`
- [x] `(. ./shell.env && echo "$SHELL")` → `/usr/bin/zsh`
- [x] Symlink chain verified: `~/.config/environment.d/shell.conf` → dotfiles env.d → `../shell.env`
- [ ] Open fresh Ghostty and confirm `echo $SHELL` shows zsh
- [ ] Full logout/login and verify `$SHELL` stays zsh across reboots