### PR TITLE
Add vpn-on-dev/prod/vpn-off aliases for OpenVPN

### DIFF
--- a/vpn/aliases.zsh
+++ b/vpn/aliases.zsh
@@ -1,0 +1,11 @@
+# OpenVPN systemd-unit shortcuts.
+#
+# Configs live at /etc/openvpn/client/<name>.conf (mode 600), started via the
+# openvpn-client@<name>.service template unit.
+
+if [[ "$OSTYPE" == "linux"* ]]; then
+  alias vpn-on-dev='sudo systemctl start openvpn-client@soffi-dev'
+  alias vpn-on-prod='sudo systemctl start openvpn-client@soffi-prod'
+  alias vpn-off='sudo systemctl stop "openvpn-client@*"'
+  alias vpn-status='systemctl status "openvpn-client@*" --no-pager'
+fi


### PR DESCRIPTION
New `vpn/` topic with four aliases — `vpn-on-dev`, `vpn-on-prod`, `vpn-off`, `vpn-status` — wrapping the `systemctl … openvpn-client@<name>` invocations. Gated on Linux so mac sessions don't define dead names. Pairs with the soffi-dev / soffi-prod configs installed at `/etc/openvpn/client/`.

`vpn-off` uses systemd's `openvpn-client@*` unit pattern (quoted so zsh doesn't glob-expand) so it stops whichever instance is running without needing to know which.