### PR TITLE
Add gammastep for blue light filtering on Linux

### DIFF
--- a/linux/gammastep/config.ini
+++ b/linux/gammastep/config.ini
@@ -1,0 +1,11 @@
+[general]
+temp-day=6500
+temp-night=4500
+brightness-day=1.0
+brightness-night=1.0
+location-provider=manual
+adjustment-method=wayland
+
+[manual]
+lat=52.37
+lon=4.90

--- a/linux/gammastep/install.sh
+++ b/linux/gammastep/install.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+#
+# Enable gammastep as a per-user service.
+# Package install is handled in script/install (pacman).
+# Config is symlinked in script/bootstrap.
+
+[ "$(uname -s)" = "Linux" ] || exit 0
+
+if ! command -v gammastep >/dev/null 2>&1; then
+  echo "  Skipping gammastep service enable — binary not found"
+  exit 0
+fi
+
+if ! command -v systemctl >/dev/null 2>&1; then
+  exit 0
+fi
+
+if systemctl --user is-enabled --quiet gammastep.service 2>/dev/null; then
+  echo "  gammastep user service already enabled"
+else
+  echo "  Enabling gammastep user service"
+  systemctl --user enable --now gammastep.service
+fi

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -217,6 +217,10 @@ install_larger_paths () {
     # systemd-user environment overrides
     mkdir -p "$HOME/.config/environment.d"
     link_file "$DOTFILES_ROOT/linux/environment.d/shell.conf" "$HOME/.config/environment.d/shell.conf"
+
+    # gammastep — blue light filter, manual location set in the config
+    mkdir -p "$HOME/.config/gammastep"
+    link_file "$DOTFILES_ROOT/linux/gammastep/config.ini" "$HOME/.config/gammastep/config.ini"
   fi
 }
 

--- a/script/install
+++ b/script/install
@@ -14,7 +14,7 @@ elif command -v pacman >/dev/null 2>&1; then
   echo "› installing packages via pacman"
   sudo pacman -S --needed --noconfirm \
     zsh starship mise neovim github-cli jq yq fzf fd ast-grep uv jujutsu keyd \
-    bun actionlint syncthing \
+    bun actionlint syncthing gammastep \
     ttf-ibmplex-mono-nerd \
     firefox telegram-desktop signal-desktop zed
 


### PR DESCRIPTION
## Background

macOS has Night Shift built in; Hyprland on Arch doesn't. Wanting the same evening color-temperature behavior on the Linux box after getting Syncthing wired up. gammastep is the Wayland-native fork of redshift and the de facto answer on Hyprland.

## Approach

New `linux/gammastep/` topic with a `config.ini` (manual location, Amsterdam) and an `install.sh` that enables `gammastep.service` as a per-user systemd unit. Package added to the pacman list in `script/install`; config symlink rides in `script/bootstrap`'s Linux block. 6500K day / 4500K night to roughly match Night Shift's feel.

## Reviewer notes

- Topic lives under `linux/` since macOS has Night Shift natively.
- `adjustment-method=wayland` pinned explicitly; gammastep usually auto-detects but pinning avoids X11 fallback surprises.
- `install.sh` self-guards on `uname` so the topic-installer pass in `script/install` no-ops cleanly on a Mac.

## Testing plan

- Ran the install pipeline on this Arch box: pacman pulled in gammastep 2.0.11, topic installer enabled the user service via `systemctl --user enable --now gammastep.service`.
- `systemctl --user is-active gammastep.service` returns active; service auto-starts at login.
- Visually confirmed screen warms after sunset for Amsterdam coordinates.