### PR TITLE
Add Mac-style Alt-as-Cmd keyd remap for GUI apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Cross-platform topics live at the repo root. OS-specific topics live under `linu
 |-------|-------------|
 | `linux/environment.d/` | systemd-user env (currently the `$SHELL` override; symlinks to root-level `shell.env`) |
 | `linux/hyprland/` | Hyprland WM overrides — bindings + input |
-| `linux/keyd/` | keyd keyboard remapper config (Caps → Hyper) |
+| `linux/keyd/` | keyd keyboard remapper config (Caps → Hyper, Alt → Ctrl in GUI apps) |
 | `linux/vpn/` | OpenVPN systemd-unit aliases |
 
 **macOS-only (`macos/`):**

--- a/linux/hyprland/autostart.conf
+++ b/linux/hyprland/autostart.conf
@@ -1,0 +1,6 @@
+# Hyprland autostart — extra processes to launch with the session.
+
+# keyd's per-app remapping needs this user-space helper running so the
+# daemon knows which window is focused. Without it, every [app] section
+# in /etc/keyd/default.conf is a no-op.
+exec-once = keyd-application-mapper -d

--- a/linux/hyprland/bindings.conf
+++ b/linux/hyprland/bindings.conf
@@ -25,6 +25,11 @@ bindd = $hyper, F, File manager (focus or launch), exec, omarchy-launch-or-focus
 bindd = $hyper, G, Terminal, exec, uwsm-app -- xdg-terminal-exec
 bindd = $hyper, C, Obsidian, exec, omarchy-launch-or-focus ^obsidian$ "uwsm-app -- obsidian --disable-gpu --enable-wayland-ime"
 
+# Mac-style Cmd+Q quit. In apps where keyd rewrites Alt→Ctrl
+# (Firefox, Slack, Zed, etc.) the app sees Ctrl+Q and quits itself;
+# elsewhere this Hyprland binding fires killactive.
+bindd = ALT, Q, Close window, killactive
+
 # Window management — matches Fn+Hyper on macOS
 bindd = $hyper, up, Toggle maximize, fullscreen, 0
 bindd = $hyper, down, Toggle floating, togglefloating

--- a/linux/keyd/app.conf
+++ b/linux/keyd/app.conf
@@ -1,0 +1,79 @@
+# Mac-style Alt-as-Cmd in GUI apps.
+#
+# Symlinked to ~/.config/keyd/app.conf; consumed by
+# keyd-application-mapper (started from Hyprland's autostart.conf).
+#
+# Section names must match the *normalized* class — the mapper does
+# re.sub('[^A-Za-z0-9]+', '-', cls).lower() on the wayland app_id
+# before lookup. So `dev.zed.Zed` becomes `dev-zed-zed`,
+# `chrome-mail.google.com__-Default` becomes
+# `chrome-mail-google-com-default`, etc.
+#
+# Use the canonical key names (`leftalt`/`leftcontrol`, not the `alt`
+# / `control` aliases). The aliases work in /etc/keyd/default.conf
+# but `keyd bind`, which the mapper invokes per-app, rejects them.
+#
+# `overload(ctrl_mod, leftalt)`: held + another key → Ctrl+key, tapped
+# alone → Alt. Keeps Firefox's menu-bar accelerator working.
+# `ctrl_mod` layer is defined in default.conf.
+#
+# Ghostty is intentionally omitted: terminal apps need real Alt for
+# word-navigation (Alt+B/F) and Ghostty has its own Cmd-style binds.
+
+[firefox]
+
+leftalt = overload(ctrl_mod, leftalt)
+rightalt = overload(ctrl_mod, rightalt)
+
+[slack]
+
+leftalt = overload(ctrl_mod, leftalt)
+rightalt = overload(ctrl_mod, rightalt)
+
+[dev-zed-zed]
+
+leftalt = overload(ctrl_mod, leftalt)
+rightalt = overload(ctrl_mod, rightalt)
+
+[obsidian]
+
+leftalt = overload(ctrl_mod, leftalt)
+rightalt = overload(ctrl_mod, rightalt)
+
+[signal]
+
+leftalt = overload(ctrl_mod, leftalt)
+rightalt = overload(ctrl_mod, rightalt)
+
+[org-telegram-desktop]
+
+leftalt = overload(ctrl_mod, leftalt)
+rightalt = overload(ctrl_mod, rightalt)
+
+[org-gnome-nautilus]
+
+leftalt = overload(ctrl_mod, leftalt)
+rightalt = overload(ctrl_mod, rightalt)
+
+[spotify]
+
+leftalt = overload(ctrl_mod, leftalt)
+rightalt = overload(ctrl_mod, rightalt)
+
+# Chromium-based PWAs (omarchy-launch-webapp creates these with
+# class like chrome-<hostname>__-Default, normalized to dashes).
+
+[chrome-mail-google-com-default]
+
+leftalt = overload(ctrl_mod, leftalt)
+rightalt = overload(ctrl_mod, rightalt)
+
+[chrome-calendar-google-com-default]
+
+leftalt = overload(ctrl_mod, leftalt)
+rightalt = overload(ctrl_mod, rightalt)
+
+[chrome-web-whatsapp-com-default]
+
+leftalt = overload(ctrl_mod, leftalt)
+rightalt = overload(ctrl_mod, rightalt)

--- a/linux/keyd/default.conf
+++ b/linux/keyd/default.conf
@@ -12,3 +12,8 @@ h = left
 j = down
 k = up
 l = right
+
+# Bare Ctrl-modifier layer. Referenced by app.conf overload actions
+# so Alt held + key acts as Ctrl+key (Mac-style chord), while Alt
+# tapped alone still emits Alt (so Firefox's menu bar etc. work).
+[ctrl_mod:C]

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -212,7 +212,13 @@ install_larger_paths () {
     if [ -d "$HOME/.config/hypr" ]; then
       link_file "$DOTFILES_ROOT/linux/hyprland/bindings.conf" "$HOME/.config/hypr/bindings.conf"
       link_file "$DOTFILES_ROOT/linux/hyprland/input.conf" "$HOME/.config/hypr/input.conf"
+      link_file "$DOTFILES_ROOT/linux/hyprland/autostart.conf" "$HOME/.config/hypr/autostart.conf"
     fi
+
+    # keyd per-user app remaps (Alt-as-Cmd in GUI apps). Consumed by
+    # keyd-application-mapper, which Hyprland autostarts.
+    mkdir -p "$HOME/.config/keyd"
+    link_file "$DOTFILES_ROOT/linux/keyd/app.conf" "$HOME/.config/keyd/app.conf"
 
     # Waybar config override (clock format + module layout)
     if [ -d "$HOME/.config/waybar" ]; then


### PR DESCRIPTION
## Background
Bouncing between Cmd-style binds on Mac and the mix of Ctrl/Super/Alt on Linux meant constant friction. Closing a tab/window was Alt+W in some apps, Super+W in Omarchy, Ctrl+W in browsers — three different chords for the same intent. Goal: Alt-as-Cmd wherever a Mac app uses Cmd, terminal left alone.

## Approach
Per-app keyd remap in `~/.config/keyd/app.conf`. Each targeted app (Firefox, Slack, Zed, Obsidian, Signal, Telegram, Nautilus, Spotify, the Chromium PWAs) gets `leftalt = overload(ctrl_mod, leftalt)` so held Alt+key fires Ctrl+key but tapped Alt alone still emits Alt (so Firefox's menu bar still opens). A small `[ctrl_mod:C]` layer in default.conf gives `overload` something to reference.

The mapper (`keyd-application-mapper`) is autostarted from Hyprland's new `autostart.conf`. Bootstrap symlinks both new config files. Also added a Hyprland `Alt+Q` → `killactive` for Cmd+Q-style quit.

## Reviewer notes
A few keyd 2.x quirks shaped the config:
- Section names get normalized via `re.sub('[^A-Za-z0-9]+', '-', s).lower()`, so the wayland app_id `dev.zed.Zed` becomes `[dev-zed-zed]`.
- `keyd bind` (which the mapper invokes per focus change) rejects key aliases like `alt`/`control`, even though the config parser accepts them. Canonical names only in `app.conf`.
- The keyd socket is `root:keyd 660`. A fresh machine bootstrap will hit a permissions wall until `usermod -aG keyd $USER` runs — not yet in `script/install`. Worth a follow-up.

## Testing plan
- [x] Alt+T / Alt+W / Alt-tap (menu bar) in Firefox
- [x] Alt+B/F word-nav still works in Ghostty
- [ ] Reboot to verify mapper autostarts cleanly from Hyprland exec-once