### PR TITLE
Fix code-intel codegraph install: standalone binary, not npm global

### DIFF
--- a/code-intel/install.sh
+++ b/code-intel/install.sh
@@ -36,21 +36,31 @@ else
 fi
 
 # --- codegraph: structural graph over MCP (TRAVERSE) ----------------------
-if command -v npm >/dev/null 2>&1; then
-  if ! command -v codegraph >/dev/null 2>&1; then
-    echo "  Installing codegraph..."
-    npm install -g @colbymchenry/codegraph || true
+# Install the standalone bundled-runtime build (ships its own Node), NOT
+# `npm i -g`: under mise, an npm-global bin becomes a shim that fails in any
+# project pinning a different node version ("No version is set for shim"), and
+# it needs node present at all (not guaranteed on Linux). The launcher resolves
+# symlinks, so a ~/.local/bin symlink into the bundle is the supported install.
+if ! command -v codegraph >/dev/null 2>&1; then
+  echo "  Installing codegraph (standalone)..."
+  cg_os=$(uname -s | tr '[:upper:]' '[:lower:]')
+  cg_arch=$(uname -m); case "$cg_arch" in x86_64|amd64) cg_arch=x64;; aarch64) cg_arch=arm64;; esac
+  cg_dir="codegraph-${cg_os}-${cg_arch}"
+  cg_url="https://github.com/colbymchenry/codegraph/releases/latest/download/${cg_dir}.tar.gz"
+  mkdir -p "$HOME/.local/lib" "$HOME/.local/bin"
+  if curl -fsSL "$cg_url" | tar -xz -C "$HOME/.local/lib"; then
+    ln -sf "$HOME/.local/lib/$cg_dir/bin/codegraph" "$HOME/.local/bin/codegraph"
+  else
+    echo "  codegraph download failed (${cg_dir}.tar.gz)"
   fi
-  # Register the MCP server ourselves (user scope, machine-local) rather than
-  # `codegraph install`, which would append instructions into the
-  # dotfiles-managed ~/.claude/CLAUDE.md. Tool permissions live in settings.json.
-  if command -v claude >/dev/null 2>&1 \
-    && ! claude mcp list 2>/dev/null | grep -qi '^codegraph'; then
-    echo "  Registering codegraph MCP server..."
-    claude mcp add -s user codegraph -- codegraph serve --mcp || true
-  fi
-else
-  echo "  Skipping codegraph — npm (node) not found"
+fi
+# Register the MCP server ourselves (user scope, machine-local) rather than
+# `codegraph install`, which would append instructions into the
+# dotfiles-managed ~/.claude/CLAUDE.md. Tool permissions live in settings.json.
+if command -v codegraph >/dev/null 2>&1 && command -v claude >/dev/null 2>&1 \
+  && ! claude mcp list 2>/dev/null | grep -qi '^codegraph'; then
+  echo "  Registering codegraph MCP server..."
+  claude mcp add -s user codegraph -- codegraph serve --mcp || true
 fi
 
 # --- graphify: knowledge graph (COMPREHEND) -------------------------------


### PR DESCRIPTION
## Background

codegraph was installed via `npm i -g @colbymchenry/codegraph` (from PR #76). Under mise, an npm-global bin becomes a mise **shim** — and in any project that pins its own node version, the shim can't resolve one:

```
▸ codegraph
mise ERROR No version is set for shim: codegraph
```

That's exactly what surfaced running `code-intel status` in soffi-main (which pins its own node). The same install method also assumes node is present at all, which isn't guaranteed on Linux — so it was a latent cross-platform problem, not just a local one.

## Approach

Install codegraph's **standalone, bundled-runtime release** instead — it ships its own Node, so it's independent of mise and of any system node. `code-intel/install.sh` now:

- detects OS/arch (`uname`), maps to the release naming (`x86_64`→`x64`, `aarch64`→`arm64`),
- downloads the matching `codegraph-<os>-<arch>.tar.gz` from GitHub releases into `~/.local/lib`,
- symlinks `~/.local/bin/codegraph` into the bundle — the launcher resolves symlinks by design, so this is the supported install shape.

Fixes the macOS shim failure and the Linux node gap in one move. MCP registration (user scope) and the settings.json permissions are unchanged.

## Reviewer notes

- Graceful fallback: if the download fails, it prints a message and the rest of `install.sh` continues.
- The `command -v codegraph` guard means `install.sh` won't auto-replace an existing (e.g. npm) install — that migration was done by hand on this machine.

## Testing plan

- Reproduced the failure: `code-intel status` in soffi-main → `mise ERROR No version is set for shim: codegraph`.
- Removed the npm global + stale mise shim, installed the standalone `darwin-arm64` build, symlinked it.
- `codegraph status` in soffi-main now works (33k nodes, no error); `codegraph --version` → `0.9.4` resolving from `~/.local/bin/codegraph`.
- `sh -n code-intel/install.sh` passes.
