### PR TITLE
Add code-intel warm: seed worktree indexes from the main worktree

### DIFF
--- a/bin/claude-review
+++ b/bin/claude-review
@@ -142,10 +142,16 @@ case "$1" in
       new_wt=true
     fi
 
+    # Resolve code-intel by this script's own dir (cwd/`./bin` could shadow it).
+    code_intel="$(cd "$(dirname "$0")" && pwd)/code-intel"
     cd "$WT_PATH"
-    # Seed code-intel indexes from the main worktree so the session starts hot.
-    if [ "$new_wt" = true ] && command -v code-intel >/dev/null 2>&1; then
-      code-intel warm || true
+    # Seed code-intel indexes from the main worktree in the background, so the
+    # session launches now and the indexes fill in within seconds (logged, not
+    # printed, to keep them out of Claude's TUI).
+    if [ "$new_wt" = true ] && [ -x "$code_intel" ]; then
+      warm_log="${TMPDIR:-/tmp}/code-intel-warm-$WT_NAME.log"
+      echo "› warming code-intel indexes in background (log: $warm_log)"
+      nohup "$code_intel" warm >"$warm_log" 2>&1 &
     fi
     claude --dangerously-skip-permissions "$@"
 

--- a/bin/claude-review
+++ b/bin/claude-review
@@ -121,6 +121,7 @@ case "$1" in
     if [ -d "$WT_PATH" ]; then
       echo "Worktree already exists at $WT_PATH"
       echo "Resuming review..."
+      new_wt=false
     else
       mkdir -p "$WORKTREE_DIR"
 
@@ -138,9 +139,14 @@ case "$1" in
           git worktree add -b "$TARGET" "$WT_PATH" "origin/$TARGET"
         fi
       fi
+      new_wt=true
     fi
 
     cd "$WT_PATH"
+    # Seed code-intel indexes from the main worktree so the session starts hot.
+    if [ "$new_wt" = true ] && command -v code-intel >/dev/null 2>&1; then
+      code-intel warm || true
+    fi
     claude --dangerously-skip-permissions "$@"
 
     # Offer cleanup when claude exits

--- a/bin/claude-work
+++ b/bin/claude-work
@@ -138,10 +138,16 @@ case "$1" in
       new_wt=true
     fi
 
+    # Resolve code-intel by this script's own dir (cwd/`./bin` could shadow it).
+    code_intel="$(cd "$(dirname "$0")" && pwd)/code-intel"
     cd "$WT_PATH"
-    # Seed code-intel indexes from the main worktree so the session starts hot.
-    if [ "$new_wt" = true ] && command -v code-intel >/dev/null 2>&1; then
-      code-intel warm || true
+    # Seed code-intel indexes from the main worktree in the background, so the
+    # session launches now and the indexes fill in within seconds (logged, not
+    # printed, to keep them out of Claude's TUI).
+    if [ "$new_wt" = true ] && [ -x "$code_intel" ]; then
+      warm_log="${TMPDIR:-/tmp}/code-intel-warm-$WT_NAME.log"
+      echo "› warming code-intel indexes in background (log: $warm_log)"
+      nohup "$code_intel" warm >"$warm_log" 2>&1 &
     fi
     claude --dangerously-skip-permissions "$@"
 

--- a/bin/claude-work
+++ b/bin/claude-work
@@ -123,6 +123,7 @@ case "$1" in
     if [ -d "$WT_PATH" ]; then
       echo "Worktree already exists at $WT_PATH"
       echo "Resuming..."
+      new_wt=false
     else
       if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
         echo "Branch '$BRANCH' already exists. Use claude-review to attach to it." >&2
@@ -134,9 +135,14 @@ case "$1" in
       DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||') || DEFAULT_BRANCH="main"
       git fetch origin "$DEFAULT_BRANCH" 2>/dev/null || true
       git worktree add -b "$BRANCH" "$WT_PATH" "origin/$DEFAULT_BRANCH"
+      new_wt=true
     fi
 
     cd "$WT_PATH"
+    # Seed code-intel indexes from the main worktree so the session starts hot.
+    if [ "$new_wt" = true ] && command -v code-intel >/dev/null 2>&1; then
+      code-intel warm || true
+    fi
     claude --dangerously-skip-permissions "$@"
 
     echo ""

--- a/bin/code-intel
+++ b/bin/code-intel
@@ -62,6 +62,27 @@ ci_status() {
   fi
 }
 
+ci_warm() {
+  # Seed this worktree's indexes from the repo's main worktree, then reconcile.
+  # Far cheaper than a cold build: vera detects unchanged files by content, so
+  # `vera update` after a copy re-embeds only this branch's diffs (seconds).
+  src=$(git worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2; exit}')
+  here=$(pwd -P)
+  if [ -z "$src" ] || [ "$src" = "$here" ]; then
+    note "no source worktree to warm from — run: code-intel init"
+    return 0
+  fi
+  step "warming from $src"
+  for idx in .vera .codegraph graphify-out; do
+    if [ -d "$src/$idx" ] && [ ! -e "$idx" ]; then
+      cp -R "$src/$idx" "./$idx" && note "copied $idx"
+    fi
+  done
+  if have vera      && [ -d .vera ];        then step "vera — update";    vera update .;   fi
+  if have codegraph && [ -d .codegraph ];   then step "codegraph — sync"; codegraph sync;  fi
+  if have graphify  && [ -d graphify-out ]; then step "graphify — update"; graphify update .; fi
+}
+
 show_help() {
   cat << 'EOF'
 Usage: code-intel <command>
@@ -72,6 +93,7 @@ project in the current directory.
 Commands:
   init      Build all three indexes from scratch (+ graphify commit hook)
   refresh   Update all three after edits
+  warm      Seed indexes from the main worktree + reconcile (for new worktrees)
   status    Show index state for each tool
   help      Show this help
 
@@ -88,6 +110,7 @@ EOF
 case "${1:-help}" in
   init)            ci_init ;;
   refresh|update)  ci_refresh ;;
+  warm)            ci_warm ;;
   status)          ci_status ;;
   help|-h|--help)  show_help ;;
   *) printf 'Unknown command: %s\n\n' "${1:-}"; show_help; exit 1 ;;

--- a/bin/git-tree
+++ b/bin/git-tree
@@ -207,6 +207,7 @@ EOF
            git show-ref --verify --quiet "refs/remotes/origin/$branch"; then
             git worktree add "$path" "$branch"
             echo "✓ Worktree created at: $path"
+            ( cd "$path" && command -v code-intel >/dev/null 2>&1 && code-intel warm ) 1>&2 || true
             echo "TREE_ME_CD:$path"
         else
             echo "Error: Branch '$branch' does not exist" >&2
@@ -231,6 +232,7 @@ EOF
         # Create new branch
         git worktree add "$path" -b "$branch" "$base"
         echo "✓ Worktree created at: $path"
+        ( cd "$path" && command -v code-intel >/dev/null 2>&1 && code-intel warm ) 1>&2 || true
         echo "TREE_ME_CD:$path"
         ;;
 
@@ -260,6 +262,7 @@ EOF
         git fetch origin "pull/$pr_number/head:$branch" 2>/dev/null || true
         git worktree add "$path" "$branch"
         echo "✓ PR #$pr_number checked out at: $path"
+        ( cd "$path" && command -v code-intel >/dev/null 2>&1 && code-intel warm ) 1>&2 || true
         echo "TREE_ME_CD:$path"
         ;;
 

--- a/bin/git-tree
+++ b/bin/git-tree
@@ -77,6 +77,21 @@ get_pr_number() {
     fi
 }
 
+# Seed code-intel indexes in a fresh worktree, detached + logged so it survives
+# this command exiting and never blocks the auto-cd (which parses stdout).
+warm_worktree() {
+    # Resolve code-intel by this script's own dir, not PATH — otherwise the
+    # `./bin` PATH entry + a worktree cwd would shadow it with the worktree's
+    # own (possibly older) copy.
+    local cg; cg="$(cd "$(dirname "$0")" && pwd)/code-intel"
+    [ -x "$cg" ] || return 0
+    local wt="$1"
+    local log="${TMPDIR:-/tmp}/code-intel-warm-$(basename "$wt").log"
+    ( cd "$wt" && "$cg" warm ) >"$log" 2>&1 &
+    disown 2>/dev/null || true
+    echo "› warming code-intel indexes in background (log: $log)" >&2
+}
+
 repo=$(get_repo_name)
 command="$1"
 shift
@@ -207,7 +222,7 @@ EOF
            git show-ref --verify --quiet "refs/remotes/origin/$branch"; then
             git worktree add "$path" "$branch"
             echo "✓ Worktree created at: $path"
-            ( cd "$path" && command -v code-intel >/dev/null 2>&1 && code-intel warm ) 1>&2 || true
+            warm_worktree "$path"
             echo "TREE_ME_CD:$path"
         else
             echo "Error: Branch '$branch' does not exist" >&2
@@ -232,7 +247,7 @@ EOF
         # Create new branch
         git worktree add "$path" -b "$branch" "$base"
         echo "✓ Worktree created at: $path"
-        ( cd "$path" && command -v code-intel >/dev/null 2>&1 && code-intel warm ) 1>&2 || true
+        warm_worktree "$path"
         echo "TREE_ME_CD:$path"
         ;;
 
@@ -262,7 +277,7 @@ EOF
         git fetch origin "pull/$pr_number/head:$branch" 2>/dev/null || true
         git worktree add "$path" "$branch"
         echo "✓ PR #$pr_number checked out at: $path"
-        ( cd "$path" && command -v code-intel >/dev/null 2>&1 && code-intel warm ) 1>&2 || true
+        warm_worktree "$path"
         echo "TREE_ME_CD:$path"
         ;;
 


### PR DESCRIPTION
## Background

The code-intel indexes (`.vera/`, `.codegraph/`, `graphify-out/`) are gitignored and per-directory, so a new git worktree starts cold — no indexes. For a worktree-heavy flow (`claude-work`, `claude-review`, occasionally `git-tree`), that meant re-indexing from scratch, and for vera that's minutes on a big repo.

Testing showed vera detects unchanged files by **content**, not mtime — so a fresh checkout's mtime rewrite doesn't defeat it. Copying `.vera/` then `vera update` re-embeds only the branch's diffs (seconds), which is the whole idea here.

## Approach

New **`code-intel warm`** subcommand: finds the repo's main worktree (`git worktree list`), copies any of the three index dirs it has into the current worktree (skipping ones already present), then reconciles each — `vera update` / `codegraph sync` / `graphify update`. Idempotent.

Wired into **`claude-work`**, **`claude-review`**, and **`git-tree`** (create/checkout/pr), running **in the background** (detached + logged) so the session or worktree is usable immediately and the indexes fill in behind it — nothing blocks on the copy, and warm output stays out of Claude's TUI / git-tree's auto-cd parsing.

## Reviewer notes

- **Resolves `code-intel` by the calling script's own dir**, not bare `command -v` — otherwise a worktree cwd plus the `./bin` entry in `$PATH` shadows it with the *worktree's own* copy of code-intel (which, for a branch predating this feature, lacks `warm` and just prints help). Caught this in testing.
- Only warms **new** worktrees (a `new_wt` flag); resume is untouched.
- Detached via `nohup … &` (claude-work/review) and `( … ) & disown` (git-tree, where stdout is captured for the auto-cd marker — so warm output is redirected to a log and never blocks the `$(…)`).
- Guards on the resolved path being executable, so the worktree tools still work if code-intel or a source index is missing.
- `claude-review` checks out PRs that differ more from main, so its `vera update` re-embeds more — still far cheaper than cold.

## Testing plan

- `git-tree create` on a worktree off main: **returns in ~0.5s** (detached, not blocked); the background warm then copies all three indexes, `vera update` reports **443 unchanged / 4.66s**, codegraph sync + graphify update run, all three index dirs present.
- Confirmed the shadowing fix: with a worktree checked out at pre-`warm` content, the warm still ran `ci_warm` (resolved code-intel from the script dir) rather than printing help.
- `bash -n` / `sh -n` clean on all four scripts.
