### PR TITLE
Sync Zed extensions via auto_install_extensions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,3 +57,4 @@ Bootstrap uses **relative symlinks** (via perl `File::Spec->abs2rel`) so they wo
 - BTT presets are not auto-synced; manual export/import is required after changes
 - BTT preset arrow-key bindings store an implicit Fn modifier (`BTTShortcutModifierKeys: 10354688` = Hyper+Fn) because Apple keyboards attach Fn to arrow keys at the hardware level. When documenting those shortcuts, write them as `Hyper+Up` etc. — not `Fn+Hyper+Up`.
 - `nvim/lazy-lock.json` tracks neovim plugin versions — changes here are from plugin updates
+- Zed extensions are synced declaratively via `auto_install_extensions` in `zed/settings.json` — add new registry extensions there so other machines pick them up (Zed doesn't write back to this list).

--- a/zed/settings.json
+++ b/zed/settings.json
@@ -7,6 +7,17 @@
 // custom settings, run `zed: open default settings` from the
 // command palette (cmd-shift-p / ctrl-shift-p)
 {
+  // Install these on any machine sharing this file. Keeps extensions in
+  // sync across boxes; quakefile is a local dev extension and is loaded
+  // separately via "zed: install dev extension".
+  "auto_install_extensions": {
+    "dockerfile": true,
+    "html": true,
+    "make": true,
+    "ruby": true,
+    "terraform": true,
+    "zig": true
+  },
   "cli_default_open_behavior": "new_window",
   "project_panel": {
     "dock": "left"


### PR DESCRIPTION
## Background

Zed extensions live in `~/Library/Application Support/Zed/extensions/` (or `~/.local/share/zed/` on Linux) and aren't tracked by the dotfiles — only `settings.json`, `keymap.json`, and themes are. So a fresh machine (the Linux box) ends up with none of them installed.

## Approach

Declare the six registry extensions (`dockerfile`, `html`, `make`, `ruby`, `terraform`, `zig`) in `auto_install_extensions` in the tracked `settings.json`. Zed installs any missing ones on startup, on every machine sharing the file. The local `quakefile` dev extension is excluded since it's not in the registry. Added a note to `CLAUDE.md` recording the convention and that Zed doesn't write back to this list.

## Testing plan

Restart Zed on a machine missing the extensions and confirm they auto-install. Real validation happens on the Linux box once `~/.config/zed` is symlinked.