### PR TITLE
Harden sshd via key-only auth, no root login

### DIFF
--- a/linux/ssh/sshd-hardening.conf
+++ b/linux/ssh/sshd-hardening.conf
@@ -1,0 +1,20 @@
+# OpenSSH server hardening — deployed to /etc/ssh/sshd_config.d/10-hardening.conf
+# by script/install. The 10- prefix sorts ahead of Arch's 99-archlinux.conf so
+# these win. Key-only auth, no root login.
+#
+# WARNING: with PasswordAuthentication off you can only get in with a key.
+# Confirm key auth works in a separate session before relying on this.
+
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+PubkeyAuthentication yes
+
+PermitRootLogin no
+
+# Tighten the brute-force surface.
+MaxAuthTries 3
+LoginGraceTime 30
+
+# Restrict to specific accounts if you want — left off so this config stays
+# portable across machines with different usernames:
+# AllowUsers bnferguson

--- a/script/install
+++ b/script/install
@@ -13,7 +13,7 @@ if command -v brew >/dev/null 2>&1; then
 elif command -v pacman >/dev/null 2>&1; then
   echo "› installing packages via pacman"
   sudo pacman -S --needed --noconfirm \
-    zsh starship mise neovim github-cli jq go-yq fzf fd ast-grep uv jujutsu keyd \
+    zsh starship mise neovim github-cli jq go-yq fzf fd ast-grep uv jujutsu keyd openssh \
     actionlint syncthing gammastep \
     ttf-ibmplex-mono-nerd \
     firefox telegram-desktop signal-desktop zed
@@ -41,6 +41,21 @@ elif command -v pacman >/dev/null 2>&1; then
     sudo cp "$DOTFILES_ROOT/linux/keyd/default.conf" /etc/keyd/default.conf
     sudo systemctl enable keyd
     sudo systemctl restart keyd
+  fi
+
+  # sshd — key-only auth, no root login. Validate the merged config before
+  # reloading and back out the drop-in on failure so we can't lock ourselves out.
+  if [ -f "$DOTFILES_ROOT/linux/ssh/sshd-hardening.conf" ]; then
+    echo "› hardening sshd"
+    sudo install -m 0644 "$DOTFILES_ROOT/linux/ssh/sshd-hardening.conf" \
+      /etc/ssh/sshd_config.d/10-hardening.conf
+    if sudo sshd -t; then
+      sudo systemctl enable --now sshd
+      sudo systemctl reload sshd
+    else
+      echo "  sshd config test failed; removing drop-in to avoid lockout" >&2
+      sudo rm -f /etc/ssh/sshd_config.d/10-hardening.conf
+    fi
   fi
 elif command -v apt-get >/dev/null 2>&1; then
   echo "› installing packages via apt"


### PR DESCRIPTION
## Background
SSH was off on this machine. After enabling it, logins failed — UFW had no rule for port 22 (default-drop INPUT chain), and once that was opened, the stock `sshd_config` still allowed password auth and key-based root login. This adds the server hardening as managed config so a fresh machine comes up locked down by default instead of relying on manual post-install fixes.

## Approach
Follows the existing **keyd** precedent: a system-level `/etc` config managed from the repo and deployed by `script/install`'s pacman branch.

- New `linux/ssh/sshd-hardening.conf` → deployed to `/etc/ssh/sshd_config.d/10-hardening.conf`. The `10-` prefix sorts ahead of Arch's `99-archlinux.conf` so it wins. Disables password + keyboard-interactive auth, disables root login, tightens `MaxAuthTries`/`LoginGraceTime`.
- `script/install` gains `openssh` in the package list and a deploy block that validates the merged config with `sshd -t` **before** reloading, and removes the drop-in on failure so a broken config can't lock you out.

## Reviewer notes
- `AllowUsers` is left commented out deliberately — a hardcoded username is a lockout footgun on machines where the user isn't `bnferguson`.
- The installer uses `reload` (not `restart`) so an in-flight session survives applying the change.
- `UsePAM yes` (from Arch's drop-in) is not a password backdoor here since both `PasswordAuthentication` and `KbdInteractiveAuthentication` are off.

## Testing plan
- `bash -n script/install` passes.
- Apply path verified by hand: `sudo install` the drop-in → `sudo sshd -t` returns OK → `sudo systemctl reload sshd`, then `sshd -T` confirms `passwordauthentication no` / `permitrootlogin no`.
- Lockout guard: confirm key-only login works in a separate session before relying on it.