### PR TITLE
Add Tailscale to installed apps

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -26,4 +26,5 @@ if OS.mac?
   cask "ghostty"        # terminal
   cask "1password-cli"  # secrets
   cask "jordanbaird-ice" # menubar manager
+  cask "tailscale-app"  # mesh vpn
 end

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Install these before running bootstrap, or let `dots` handle it on macOS:
 
 - Machine-specific env vars go in `~/.localrc` (not committed)
 - Git author info goes in `git/gitconfig.local.symlink` (created by bootstrap)
+- Tailscale installs and enables `tailscaled`, but you need to authenticate the machine once: `sudo tailscale up`
 
 ## maintenance
 

--- a/script/install
+++ b/script/install
@@ -14,7 +14,7 @@ elif command -v pacman >/dev/null 2>&1; then
   echo "› installing packages via pacman"
   sudo pacman -S --needed --noconfirm \
     zsh starship mise neovim github-cli jq go-yq fzf fd ast-grep uv jujutsu keyd openssh \
-    actionlint syncthing gammastep \
+    actionlint syncthing gammastep tailscale \
     ttf-ibmplex-mono-nerd \
     firefox telegram-desktop signal-desktop zed
 
@@ -56,6 +56,13 @@ elif command -v pacman >/dev/null 2>&1; then
       echo "  sshd config test failed; removing drop-in to avoid lockout" >&2
       sudo rm -f /etc/ssh/sshd_config.d/10-hardening.conf
     fi
+  fi
+
+  # tailscale — enable the daemon; `tailscale up` is left to run manually
+  # since it needs interactive auth.
+  if command -v tailscaled >/dev/null 2>&1; then
+    echo "› enabling tailscaled"
+    sudo systemctl enable --now tailscaled
   fi
 elif command -v apt-get >/dev/null 2>&1; then
   echo "› installing packages via apt"


### PR DESCRIPTION
## Background

Wanted Tailscale managed as part of the dotfiles so a new machine picks it up automatically, the same way the other apps do.

## Approach

- macOS: install the `tailscale-app` cask (the menu-bar GUI).
- Arch: add `tailscale` to the pacman list and enable `tailscaled`, following the existing keyd/sshd service pattern in `script/install`.
- `sudo tailscale up` is left manual since it needs interactive auth — documented in the README post-install section.

## Reviewer notes

The Homebrew cask was renamed `tailscale` → `tailscale-app`; the cask is the GUI app, distinct from the `tailscale` CLI formula.

## Testing plan

`script/install` runs cleanly; the `tailscaled` enable is idempotent (`systemctl enable --now`).