### PR TITLE
Remove jj snapshot hooks from Claude settings

### DIFF
--- a/claude/config/CLAUDE.md
+++ b/claude/config/CLAUDE.md
@@ -21,8 +21,6 @@ When reviewing PRs or working with branches, always check if the user is already
 ## jj as a safety net (checkpointing only)
 Do NOT use `jj` for day-to-day VCS — use `git`. But in colocated repos (`jj git init --colocate`), jj automatically snapshots the working copy whenever any `jj` command runs. This provides a recovery path when work is lost to agent crashes, context compaction, or accidental reverts.
 
-Hooks in `~/.claude/settings.json` run `jj status` at key moments (session start, pre-compact, stop) to trigger automatic snapshots. You don't need to run `jj` commands proactively — the hooks handle it.
-
 **When to check snapshots:** If something feels off after context compaction — files look different than expected, work seems missing, or the user says "wait, that's gone" — proactively check `jj obslog --revision @ --patch --limit 5` before re-doing any work. It's cheaper to restore than to recreate.
 
 **How to restore:**

--- a/claude/config/settings.json
+++ b/claude/config/settings.json
@@ -189,39 +189,6 @@
           }
         ]
       }
-    ],
-    "SessionStart": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "command -v jj >/dev/null && jj root >/dev/null 2>&1 && jj status || true"
-          }
-        ]
-      }
-    ],
-    "PreCompact": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "command -v jj >/dev/null && jj root >/dev/null 2>&1 && jj status || true"
-          }
-        ]
-      }
-    ],
-    "Stop": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "command -v jj >/dev/null && jj root >/dev/null 2>&1 && jj show --summary || true"
-          }
-        ]
-      }
     ]
   },
   "statusLine": {
@@ -324,5 +291,6 @@
   "skipDangerousModePermissionPrompt": true,
   "theme": "dark",
   "remoteControlAtStartup": true,
-  "agentPushNotifEnabled": true
+  "agentPushNotifEnabled": true,
+  "tui": "fullscreen"
 }


### PR DESCRIPTION
## Background

The `SessionStart`/`PreCompact`/`Stop` hooks ran `jj status`/`jj show` to snapshot the working copy as a recovery net in colocated repos. In practice the net caused more harm than it prevented: a snapshot fired mid-session wipes an in-progress git merge — `MERGE_HEAD` is deleted and the index reset to HEAD — so the next `git commit` finds nothing staged. This bit us for real in soffi-main (2026-06-10): a merge resolved + staged, then `git commit` failed with "no changes added to commit", with a "snapshot working copy" op sitting in between. We never actually relied on the snapshots.

## Approach

Drop the three hooks, and remove the now-false CLAUDE.md line claiming the hooks auto-snapshot. The manual jj restore guidance stays — jj still snapshots on any jj command, so the recovery path exists when you reach for it deliberately. A stray `tui: fullscreen` setting tagged along in the same file.

## Reviewer notes

The `PreToolUse`/`PostToolUse` safety hooks (rm-rf block, push-to-main block, package-manager enforce, mutation/sandbox logging) are untouched. This only removes the jj auto-checkpointing behavior.

## Testing plan

Validated the JSON with `jq empty`. Takes effect on the next Claude Code session start.

https://claude.ai/code/session_01C5b5xg1M65axxFY14C25jh