### PR TITLE
Remove conflicting rust package before installing rustup on Arch

### DIFF
--- a/script/install
+++ b/script/install
@@ -12,6 +12,18 @@ if command -v brew >/dev/null 2>&1; then
   brew bundle --file=Brewfile
 elif command -v pacman >/dev/null 2>&1; then
   echo "› installing packages via pacman"
+
+  # The standalone `rust` package conflicts with `rustup`; --noconfirm would
+  # default that prompt to "no" and abort the whole transaction. Clear it first
+  # so rustup can own the toolchain. rustup + ~/.cargo/bin provide rustc/cargo.
+  # Match a package *named* rust, not one that provides it — rustup itself
+  # declares provides=(rust), so `pacman -Q rust` resolves to rustup once it's
+  # installed and would otherwise trigger a bogus removal of a missing target.
+  if pacman -Qq | grep -qx rust; then
+    echo "› removing standalone rust package (superseded by rustup)"
+    sudo pacman -Rs --noconfirm rust
+  fi
+
   sudo pacman -S --needed --noconfirm \
     zsh starship mise neovim github-cli jq go-yq fzf fd zellij ast-grep uv rustup jujutsu keyd openssh \
     actionlint syncthing gammastep tailscale \


### PR DESCRIPTION
## Background

The rustup migration (#88) added `rustup` to the pacman package list but not a conflict guard. The standalone Arch `rust` package conflicts with `rustup`, and `--noconfirm` defaults the "Remove rust?" prompt to *no* — which aborts the entire pacman transaction. So a fresh Arch box, or any machine still carrying the standalone `rust` package, can't install rustup. This bit the migration on my own machine right after #88 merged.

## Approach

Before the pacman install, remove a present `rust` package so rustup can own the toolchain (rustup + `~/.cargo/bin` provide `rustc`/`cargo`, and `rust` has no dependents).

Detection matches a package *literally named* `rust` via `pacman -Qq | grep -qx rust`, not `pacman -Q rust`. rustup declares `provides=(rust)`, so `pacman -Q rust` resolves to rustup once it's installed and would otherwise trigger a bogus removal of a missing target — aborting `script/install` under `set -e`. (That was a real bug in the first cut of this guard.)

## Reviewer notes

- The guard is a no-op on machines that never had the standalone `rust` package, and on machines already migrated (rustup provides `rust`, but no package is named `rust`).
- `rust` has `Required By: None`, so `pacman -Rs` won't cascade into anything.

## Testing plan

- Verified the guard evaluates to "skip" in the current post-migration state (no `rust` package installed; rustup provides it).
- `bash -n script/install` passes.
- Not re-exercised against a machine that still has the standalone `rust` package — but that's the exact scenario the manual `pacman -Rs rust` resolved on this box before the guard existed, and the guard runs the same removal.

https://claude.ai/code/session_01YQfAgxCyKSaG2crwQXy7Aa