### PR TITLE
Keep sudo password prompts private during dots runs

### DIFF
--- a/bin/dots
+++ b/bin/dots
@@ -42,6 +42,14 @@ export ZSH=$HOME/.dotfiles
 
 # macOS-specific updates
 if [ "$(uname -s)" = "Darwin" ]; then
+	# Ensure passwordless sudo for softwareupdate is in place (idempotent) so the
+	# `sudo softwareupdate` in macos/scripts/install.sh doesn't prompt. Run it as a
+	# subprocess — it `exit 0`s when the rule already exists, which would otherwise
+	# abort the rest of this script when sourced.
+	if [ -x "$ZSH/macos/scripts/setup-sudoers.sh" ]; then
+		"$ZSH/macos/scripts/setup-sudoers.sh"
+	fi
+
 	if [ -f "$ZSH/macos/set-defaults.sh" ]; then
 		$ZSH/macos/set-defaults.sh
 	fi

--- a/script/install
+++ b/script/install
@@ -112,7 +112,11 @@ if [ -f shell.env ]; then
 fi
 
 # Run topic installers
-find . -name install.sh -not -path './.git/*' -not -path './script/*' | while read installer ; do
+# Read the installer list on fd 3 so each installer inherits the real stdin
+# (the terminal). Piping find into `while read` would leave stdin as the pipe,
+# and any password prompt (e.g. `sudo softwareupdate`) couldn't disable echo —
+# your typed password would be visible.
+while IFS= read -r installer <&3 ; do
   echo "› running $installer"
   sh -c "${installer}"
-done
+done 3< <(find . -name install.sh -not -path './.git/*' -not -path './script/*')


### PR DESCRIPTION
## Background

Running `dots` on macOS reaches `sudo softwareupdate -i -a` (in `macos/scripts/install.sh`), and the typed password showed up on screen instead of being masked. Root cause: `script/install` runs topic installers with `find … | while read installer`, which leaves each installer's stdin connected to the `find` pipe rather than the terminal. Without a real terminal, `sudo` can't disable echo.

The repo already had a passwordless-`softwareupdate` sudoers rule (`setup-sudoers.sh`) meant to sidestep this, but it was only wired into `bootstrap`, never `dots` — so maintenance runs still prompted. The installer loop dates to "Auto run all install.sh scripts"; the `sudo softwareupdate` + `setup-sudoers.sh` pair landed together in "Split OS-specific topics," which is where the wiring gap started.

## Approach

Two changes that fix it from both ends:

1. **`script/install`** — move the `find` output onto fd 3 (`done 3< <(find …)`, read with `read -r installer <&3`) so each installer inherits `script/install`'s real stdin. When you run `dots` interactively that's the terminal, so `sudo` masks the password. Works under `bootstrap` too, which pipes dots' *stdout* but leaves stdin as the terminal.
2. **`bin/dots`** — run `setup-sudoers.sh` at the top of the macOS path (idempotent) so the passwordless-`softwareupdate` rule is present on maintenance runs, not just first-time bootstrap. Run as a subprocess, not sourced: it `exit 0`s when the rule already exists, which would otherwise abort the rest of `dots`.

## Reviewer notes

- `script/install` has `#!/usr/bin/env bash`, so process substitution + fd redirection are safe.
- The subprocess-vs-source distinction in `bin/dots` matters: sourcing `setup-sudoers.sh` would kill the whole run every time the rule is already in place. The first-run `sudo tee` prompt inside it is private, since it runs as a direct child of `dots` with the terminal on stdin.

## Testing plan

No test harness for shell password-echo in this repo, so verified structurally:
- Confirmed the old loop starves the installer of the real stdin (installer sees the `find` pipe); the fd-3 version hands the terminal's stdin through.
- Confirmed a subprocess `exit 0` does not abort the parent script.
- `bash -n script/install` and `sh -n bin/dots` both pass; installer enumeration is unchanged.
