### PR TITLE
Install Miren CLI on all machines

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -23,10 +23,14 @@ brew "actionlint"   # github actions linter
 brew "uv"           # python package manager
 brew "rustup"       # rust toolchain manager
 
+# Third-party taps
+tap "mirendev/tap"  # miren deploy CLI (Linux gets it via the miren/ topic)
+
 # macOS casks
 if OS.mac?
   cask "ghostty"        # terminal
   cask "1password-cli"  # secrets
   cask "jordanbaird-ice" # menubar manager
   cask "tailscale-app"  # mesh vpn
+  cask "miren"          # deploy CLI for Miren runtime
 end

--- a/miren/install.sh
+++ b/miren/install.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+#
+# Install / update the Miren CLI (https://miren.dev) — deploy apps to any Linux
+# box, bare metal or cloud VM.
+#
+# Linux only: on macOS the mirendev/tap cask in the Brewfile owns Miren (and
+# handles updates via `brew upgrade`). Our Linux setup is pacman-based with no
+# Homebrew, and Miren has no pacman package, so here we do what upstream's
+# install does — a raw binary download — plus arch detection, sha256
+# verification against the published version.json, and a skip when the
+# installed version already matches so `dots` reruns stay cheap.
+#
+# Lands the binary in ~/.local/bin (already on PATH via system/path.zsh), so no
+# sudo — unlike upstream's /usr/local/bin.
+
+set -e
+
+BASE_URL="https://api.miren.cloud/assets/release/miren/latest"
+BIN_DIR="$HOME/.local/bin"
+
+case "$(uname -s)" in
+  Linux) : ;;
+  Darwin) echo "  Skipping Miren install — managed by Homebrew on macOS"; exit 0 ;;
+  *) echo "  Skipping Miren install — unsupported OS: $(uname -s)"; exit 0 ;;
+esac
+
+command -v jq >/dev/null 2>&1 || { echo "  Skipping Miren install — jq not found"; exit 0; }
+
+platform="linux"
+
+case "$(uname -m)" in
+  x86_64|amd64)  arch="amd64" ;;
+  arm64|aarch64) arch="arm64" ;;
+  *) echo "  Skipping Miren install — unsupported arch: $(uname -m)"; exit 0 ;;
+esac
+
+asset="miren-${platform}-${arch}.tar.gz"
+
+manifest="$(curl -fsSL "$BASE_URL/version.json" 2>/dev/null)" || {
+  echo "  Skipping Miren install — couldn't fetch release manifest (offline?)"
+  exit 0
+}
+
+target_version="$(printf '%s' "$manifest" | jq -r '.version')"
+want_sha="$(printf '%s' "$manifest" | jq -r --arg n "$asset" '.artifacts[] | select(.name == $n) | .sha256')"
+
+if [ -z "$want_sha" ] || [ "$want_sha" = "null" ]; then
+  echo "  Skipping Miren install — no $asset in release manifest"
+  exit 0
+fi
+
+# Already current? `miren version` prints the version in its output; match the
+# manifest's number loosely so we skip the re-download on every `dots` run.
+if command -v miren >/dev/null 2>&1 \
+  && miren version 2>/dev/null | grep -qF "${target_version#v}"; then
+  echo "  Miren already at ${target_version}"
+  exit 0
+fi
+
+echo "  Installing Miren ${target_version} (${platform}/${arch})"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+curl -fsSL -o "$tmp/$asset" "$BASE_URL/$asset"
+
+# Verify the download against the manifest's sha256 before trusting it.
+# shasum ships on macOS, sha256sum on Linux; use whichever is present.
+if command -v sha256sum >/dev/null 2>&1; then
+  got_sha="$(sha256sum "$tmp/$asset" | awk '{print $1}')"
+else
+  got_sha="$(shasum -a 256 "$tmp/$asset" | awk '{print $1}')"
+fi
+if [ "$got_sha" != "$want_sha" ]; then
+  echo "  Miren download failed checksum verification; aborting" >&2
+  echo "    expected $want_sha" >&2
+  echo "    got      $got_sha" >&2
+  exit 1
+fi
+
+tar xzf "$tmp/$asset" -C "$tmp"
+mkdir -p "$BIN_DIR"
+install -m 755 "$tmp/miren" "$BIN_DIR/miren"
+
+echo "  Miren ${target_version} installed to $BIN_DIR/miren"


### PR DESCRIPTION
## Background

### bnferguson says
I use Miren for my side projects and various one-off deployments for testing ideas etc. Problem is that my Arch box didn't have it when my Macs did. So let's get that codified in my dotfiles.

### Claude says
Miren (miren.dev) is a deploy-to-any-Linux-box CLI. It was installed on the Macs but missing on the Arch machine — nothing in the dotfiles owned it, so it drifted per-machine. Miren publishes a Homebrew tap (`mirendev/tap`), so macOS is a clean `brew` install; the Arch boxes are pacman-based with no Homebrew and Miren has no pacman package, so they need the raw binary download from upstream's docs.

## Approach

### bnferguson says
Ship it.

### Claude says
Split by platform along the lines the dotfiles already draw:

- **macOS** — add `tap "mirendev/tap"` + `cask "miren"` to the Brewfile, so `brew upgrade` keeps it current like every other tool there.
- **Linux** — a `miren/` topic installer that mirrors upstream's binary download: detects arch (amd64/arm64), verifies the download's sha256 against the published `version.json`, and installs to `~/.local/bin` (already on PATH, no sudo). It skips the download when the installed version already matches, so `dots` reruns stay cheap and offline-safe.

Both paths run automatically through `script/install` / `dots` — no manual per-machine step.

## Reviewer notes

- The Linux installer tracks `latest` rather than pinning a version. That diverges from how the `rust/` topic leaves toolchain choice deliberate; it's a judgment call, easy to pin later if drift becomes a problem.
- Fails soft: missing `jq`, no network, or an unexpected arch all `exit 0` with a message rather than aborting a bootstrap.
- The cask actually supports Linuxbrew too, but since the Linux setup never installs Homebrew, the topic installer is the only Linux path that matters.

## Testing plan

- Ran `miren/install.sh` on this Arch box: downloaded `v0.10.0`, passed sha256 verification, installed to `~/.local/bin/miren`. `miren version` reports `v0.10.0`.
- Re-ran it: correctly skipped with "Miren already at v0.10.0" (idempotency).
- `ruby -c Brewfile` passes. macOS `brew bundle` path not exercised from this Linux box — worth a spot-check on next Mac `dots` run.

https://claude.ai/code/session_01YQfAgxCyKSaG2crwQXy7Aa