### PR TITLE
Add pi coding agent config topic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ Other conventions:
 - `*.symlink` files → symlinked to `$HOME` as dotfiles (e.g., `git/gitconfig.symlink` → `~/.gitconfig`)
 - `bin/` → added to `$PATH`, contains git extensions and utilities
 - `functions/` → autoloaded zsh functions (files starting with `_` are completion functions)
-- Deeper paths (nvim, starship, gh, ghostty, ssh, jj, claude, zed, zellij at root; `linux/hyprland`, `linux/environment.d`, `macos/karabiner` under OS buckets) are symlinked into `~/.config/` or `~/.claude/` by `install_larger_paths` in bootstrap
+- Deeper paths (nvim, starship, gh, ghostty, ssh, jj, claude, pi, zed, zellij at root; `linux/hyprland`, `linux/environment.d`, `macos/karabiner` under OS buckets) are symlinked into `~/.config/`, `~/.claude/`, or `~/.pi/agent/` by `install_larger_paths` in bootstrap
 
 ## Key Architecture Details
 
@@ -44,6 +44,7 @@ Other conventions:
 - Git author config lives in `git/gitconfig.local.symlink` (created by bootstrap, gitignored)
 - jj user config lives in `~/.config/jj/conf.d/local.toml` (created by bootstrap from template)
 - Claude Code config files are symlinked individually (not the whole `~/.claude/` dir) to preserve session data
+- pi coding agent config files are symlinked individually (not the whole `~/.pi/agent/` dir) to preserve sessions, caches, and installed packages — see `pi/config/`
 - The `script/install` script supports macOS (brew), Arch (pacman), and Ubuntu (apt) with graceful fallbacks
 
 ## Symlink Strategy

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Cross-platform topics live at the repo root. OS-specific topics live under `linu
 | `kubernetes/` | kubectl completion (cached for speed) |
 | `mise/` | Global mise tool versions |
 | `nvim/` | Neovim config |
+| `pi/` | pi coding agent config — settings, custom providers |
 | `ssh/` | SSH config |
 | `starship/` | Starship prompt config |
 | `system/` | PATH, EDITOR, ls aliases, keybindings |

--- a/pi/config/models.json
+++ b/pi/config/models.json
@@ -1,0 +1,23 @@
+{
+  "providers": {
+    "lmstudio": {
+      "baseUrl": "http://localhost:1234/v1",
+      "api": "openai-completions",
+      "apiKey": "lmstudio",
+      "compat": {
+        "supportsDeveloperRole": false,
+        "supportsReasoningEffort": false,
+        "thinkingFormat": "qwen-chat-template"
+      },
+      "models": [
+        {
+          "id": "qwen/qwen3.6-27b",
+          "name": "Qwen3.6 27B (LM Studio)",
+          "reasoning": true,
+          "contextWindow": 262144,
+          "maxTokens": 32768
+        }
+      ]
+    }
+  }
+}

--- a/pi/config/settings.json
+++ b/pi/config/settings.json
@@ -1,0 +1,31 @@
+{
+  "lastChangelogVersion": "0.83.0",
+  "defaultProvider": "anthropic",
+  "defaultModel": "claude-sonnet-5",
+  "subagents": {
+    "agentOverrides": {
+      "context-builder": {
+        "model": ""
+      },
+      "planner": {
+        "model": ""
+      },
+      "researcher": {
+        "model": ""
+      },
+      "reviewer": {
+        "model": ""
+      },
+      "scout": {
+        "model": ""
+      },
+      "worker": {
+        "model": ""
+      }
+    }
+  },
+  "packages": [
+    "npm:pi-claude-cli"
+  ],
+  "theme": "dark"
+}

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -211,6 +211,12 @@ install_larger_paths () {
   mkdir -p "$HOME/.config/jj"
   link_file "$DOTFILES_ROOT/jj/config.toml" "$HOME/.config/jj/config.toml"
 
+  # pi coding agent config — symlink individual files to preserve
+  # ~/.pi/agent session data, caches, and installed packages.
+  mkdir -p "$HOME/.pi/agent"
+  link_file "$DOTFILES_ROOT/pi/config/settings.json" "$HOME/.pi/agent/settings.json"
+  link_file "$DOTFILES_ROOT/pi/config/models.json" "$HOME/.pi/agent/models.json"
+
   if [ "$(uname -s)" == "Darwin" ]; then
     link_file "$DOTFILES_ROOT/macos/karabiner" "$HOME/.config/karabiner"
   fi


### PR DESCRIPTION
## Background
I've picked up pi as a coding agent alongside Claude Code. `~/.pi/agent/` mixes real config (`settings.json`, `models.json`) with secrets and generated state (`auth.json`, `sessions/`, `cache/`, installed packages under `git/`/`npm/`). There was no dotfiles topic for it yet, so config changes weren't tracked and wouldn't survive a fresh machine setup.

## Approach
Added a `pi/config/` topic mirroring the existing `claude/config/` pattern: only the two files worth versioning (`settings.json` — provider/model defaults, theme, installed packages list; `models.json` — a custom LM Studio provider) get symlinked individually into `~/.pi/agent/` via `install_larger_paths` in `script/bootstrap`. Everything else in `~/.pi/agent/` (auth, sessions, cache, installed package contents) is left untouched on disk and never committed. Updated `README.md` and `CLAUDE.md` to document the new topic.

## Reviewer notes
Straightforward, low-risk addition — no changes to existing topics' behavior. Worth double-checking that `settings.json`'s `"packages": ["npm:pi-claude-cli"]` entry is fine to commit (it is; pi reinstalls packages automatically, nothing secret in it).

## Testing plan
Manually swapped the real `~/.pi/agent/settings.json` and `models.json` for symlinks into the repo copies and diffed old vs. new — no content changes, confirming the committed files match what was already running on this machine.