### PR TITLE
Configure LM Studio local models for pi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,9 @@ __pycache__/
 
 # Nvim (lazy.nvim installs to stdpath("data"), not in dotfiles)
 
-# Claude Code — ignore project-level settings (contains local paths)
-.claude/settings.local.json
+# Claude Code — local project state: settings with local paths, and agent
+# worktrees (real git worktrees checked out under the repo, not content to track)
+.claude/
 
 # code-intel — graphify installs its own skill per-machine (code-intel/install.sh);
 # the router skill (code-intel/) is the committed layer.

--- a/claude/config/settings.json
+++ b/claude/config/settings.json
@@ -148,7 +148,7 @@
     "ask": [],
     "defaultMode": "default"
   },
-  "model": "opus",
+  "model": "opus[1m]",
   "enableAllProjectMcpServers": false,
   "hooks": {
     "PreToolUse": [
@@ -158,10 +158,6 @@
           {
             "type": "command",
             "command": "bash ~/.claude/hooks/block-rm-rf.sh"
-          },
-          {
-            "type": "command",
-            "command": "bash ~/.claude/hooks/block-push-to-main.sh"
           },
           {
             "type": "command",
@@ -288,6 +284,7 @@
       "Thundering in your heart"
     ]
   },
+  "effortLevel": "high",
   "tui": "fullscreen",
   "skipDangerousModePermissionPrompt": true,
   "theme": "dark",

--- a/pi/config/models.json
+++ b/pi/config/models.json
@@ -1,23 +1,24 @@
 {
   "providers": {
     "lmstudio": {
-      "baseUrl": "http://localhost:1234/v1",
-      "api": "openai-completions",
-      "apiKey": "lmstudio",
-      "compat": {
-        "supportsDeveloperRole": false,
-        "supportsReasoningEffort": false,
-        "thinkingFormat": "qwen-chat-template"
-      },
-      "models": [
-        {
-          "id": "qwen/qwen3.6-27b",
-          "name": "Qwen3.6 27B (LM Studio)",
-          "reasoning": true,
-          "contextWindow": 262144,
+      "modelOverrides": {
+        "qwen/qwen3.6-35b-a3b": {
+          "contextWindow": 131072,
           "maxTokens": 32768
+        },
+        "google/gemma-4-26b-a4b-qat": {
+          "contextWindow": 65536,
+          "maxTokens": 16384
+        },
+        "prism-ml/bonsai-27b": {
+          "contextWindow": 65536,
+          "maxTokens": 16384
+        },
+        "zai-org/glm-4.7-flash": {
+          "contextWindow": 32768,
+          "maxTokens": 8192
         }
-      ]
+      }
     }
   }
 }

--- a/pi/config/settings.json
+++ b/pi/config/settings.json
@@ -1,7 +1,7 @@
 {
   "lastChangelogVersion": "0.83.0",
   "defaultProvider": "anthropic",
-  "defaultModel": "claude-sonnet-5",
+  "defaultModel": "claude-opus-5",
   "subagents": {
     "agentOverrides": {
       "context-builder": {
@@ -25,7 +25,9 @@
     }
   },
   "packages": [
-    "npm:pi-claude-cli"
+    "npm:pi-claude-cli",
+    "npm:pi-lmstudio",
+    "npm:pi-web-access"
   ],
   "theme": "dark"
 }


### PR DESCRIPTION
## Background

### bnferguson says
Getting pi in sync with the actual models that are locally on my MBP, and hopefully set up in a way that makes them work a bit better and more consistently. I have been sorta willy nilly about the settings when I loaded them, so the intent here was to get a frontier LLM to sort out what is optimal for my machine.

### Claude says
The `pi/` topic landed in #95, but the config in it was stale: it referenced `qwen/qwen3.6-27b`, which is not on this machine. Meanwhile the `pi-lmstudio` extension derives model metadata live from the server:

```ts
contextWindow: m.loaded_instances[0]?.config.context_length ?? m.max_context_length,
maxTokens:     m.max_context_length,
```

So `contextWindow` shifted with whatever happened to be loaded, and `maxTokens` was set to the entire context window. On 48GB with models up to 24GB and KV costs ranging 80-375 KB/token, that combination silently overflows.

The "willy nilly" read is supported by what was on disk: leftover per-model load configs for `qwen3-coder-30b` and a `gpt-oss-20b` that is no longer installed.

## Approach

Pin per-model `contextWindow`/`maxTokens` through `modelOverrides` rather than redefining the provider, sized from each model's actual KV-cache cost against 48GB:

| Model | Context | Max out | KV cost |
|---|---|---|---|
| `qwen/qwen3.6-35b-a3b` | 131072 | 32768 | ~80 KB/tok (MoE, vision) |
| `google/gemma-4-26b-a4b-qat` | 65536 | 16384 | ~240 KB/tok |
| `prism-ml/bonsai-27b` | 65536 | 16384 | ~256 KB/tok |
| `zai-org/glm-4.7-flash` | 32768 | 8192 | ~375 KB/tok |

Matching floors were set on the LM Studio side so JIT loads are deterministic. Reasoning format was verified by reading each model's chat template rather than guessing, and tool calling plus `chat_template_kwargs` passthrough were confirmed with live requests.

## Reviewer notes

- `npm:pi-lmstudio` must stay in the `packages` list. It registers the `lmstudio` provider; without it `models.json` is inert.
- LM Studio treats its per-model load config as a **floor**, not a cap, allocating `max(pin, auto-size)`. pi therefore always sits at or under what the server allocated. The floor still matters under memory contention, where GLM otherwise auto-sizes down to 8192.
- The LM Studio side of this is **not** in the repo. Those pins live in `~/.lmstudio/.internal/user-concrete-model-default-config/`, an undocumented path, and they are inherently machine-specific since they depend on available RAM. They deliberately are not symlinked into dotfiles.
- The second commit is unrelated pre-existing drift in `claude/config/settings.json`, split out so it can be reverted on its own. It drops the `block-push-to-main` PreToolUse hook, which is worth a look.
- `.gitignore` now ignores all of `.claude/`, which contained a real 109MB git worktree in addition to the local-paths settings file.

## Testing plan

- `pi --list-models` reflects every pinned value.
- End-to-end `pi -p` runs against `qwen3.6-35b-a3b` and `bonsai-27b` used the `read` tool successfully.
- Tool calling and `chat_template_kwargs` passthrough verified via direct API calls, returning `reasoning_content` and `reasoning_tokens`.
- Sent a 23,016-token prompt to a model pinned at 65536 with `PARALLEL 4` to confirm context is per-request and not divided across parallel slots.
- Settings and pins verified to survive a full LM Studio restart, with the server back up in 4s.