### PR TITLE
Add gh-image for uploading attachments from the shell

### DIFF
--- a/claude/config/CLAUDE.md
+++ b/claude/config/CLAUDE.md
@@ -43,6 +43,7 @@ Everything else in the gh-stack skill stands, including its rule that every comm
 
 # Tool Guidance
 - When interacting with GitHub use `gh`
+- To put an image or file into a GitHub issue, PR, or README, use `gh image <path>` — it uploads to GitHub's `user-attachments` endpoint and prints the markdown reference to paste. Uploads inherit the target repo's visibility, so private repos stay private. Infers the repo from the git remote; `--repo owner/repo` overrides. Auth comes from the browser session cookie, not the `gh` token — if it fails, check `gh image check-token`
 - Use `git` for source control
 - I use `mise` to manage my shell environment for projects
 - I use `brew` to install tools that aren't specified in `mise`

--- a/gh/install.sh
+++ b/gh/install.sh
@@ -4,16 +4,24 @@
 #
 #   gh-stack  stacked branches/PRs — pairs with the gh-stack skill in
 #             claude/config/skills/gh-stack, which documents the CLI.
+#   gh-image  uploads files to GitHub's user-attachments endpoint and prints a
+#             pasteable markdown reference — the drag-and-drop flow, in a shell.
 
 if ! command -v gh >/dev/null 2>&1; then
   echo "  Skipping gh extensions — gh not found"
   exit 0
 fi
 
-# `extension list` names the repo, not the command, so match on that.
-if gh extension list 2>/dev/null | grep -q 'github/gh-stack'; then
-  gh extension upgrade gh-stack 2>/dev/null || true
-else
-  echo "  Installing gh-stack extension..."
-  gh extension install github/gh-stack || true
-fi
+installed="$(gh extension list 2>/dev/null)"
+
+for repo in github/gh-stack drogers0/gh-image; do
+  name="${repo#*/}"
+
+  # `extension list` names the repo, not the command, so match on that.
+  if echo "$installed" | grep -q "$repo"; then
+    gh extension upgrade "$name" 2>/dev/null || true
+  else
+    echo "  Installing $name extension..."
+    gh extension install "$repo" || true
+  fi
+done


### PR DESCRIPTION
## Background

GitHub's web UI accepts drag-and-drop attachments, but there's no public API behind it — the endpoint that mints `user-attachments` URLs is internal. So getting a screenshot into an issue, PR, or README has meant leaving the terminal for the browser.

`gh-image` replicates that flow as a `gh` extension. This follows the shape 35ef5cd set for the gh topic: install the extension, then make sure it lands on a new machine and that Claude knows it exists.

## Approach

Three pieces:

- `gh extension install drogers0/gh-image` (v1.2.0)
- `gh/install.sh` grew a second extension, so the hardcoded gh-stack block became a loop over repo slugs. Same install-or-upgrade logic; `gh extension list` is now read once instead of per extension.
- A line in CLAUDE.md's tool guidance, written to fire on the situation ("I need to embed a screenshot") rather than the tool name.

## Reviewer notes

The auth model is the thing worth knowing. `gh-image` doesn't use the `gh` OAuth token — it extracts the browser's github.com **session cookie**, because the upload endpoint is internal and there's no token-scoped equivalent. Practical consequences: it depends on a live browser login, it'll break when that session expires, and `gh image check-token` is the diagnostic. `GH_SESSION_TOKEN` overrides if you'd rather pin one.

Related: this is a third-party extension (not `github/*` like gh-stack) that reads a session cookie out of the browser keychain. Worth a look at the source if that trade isn't one you want standing.

## Testing plan

- `sh gh/install.sh` — idempotent on an already-installed machine (`[image]: already up to date`), exit 0
- `gh image check-token` — reports valid, source: browser cookies, as `bnferguson`
- `gh image --help` — resolves

**Not tested:** an actual end-to-end upload. That would put a real file on GitHub's CDN, so I left it out.

https://claude.ai/code/session_0125GAAcPoChN2gkSGtKqKDr
