### PR TITLE
Stop claude-work branches from tracking origin/main

### DIFF
--- a/bin/claude-work
+++ b/bin/claude-work
@@ -134,7 +134,9 @@ case "$1" in
 
       DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||') || DEFAULT_BRANCH="main"
       git fetch origin "$DEFAULT_BRANCH" 2>/dev/null || true
-      git worktree add -b "$BRANCH" "$WT_PATH" "origin/$DEFAULT_BRANCH"
+      # --no-track: without it the new branch's upstream becomes origin/main,
+      # which breaks push.default=simple and makes pull merge main back in.
+      git worktree add --no-track -b "$BRANCH" "$WT_PATH" "origin/$DEFAULT_BRANCH"
       new_wt=true
     fi
 


### PR DESCRIPTION
## Background

Every branch started with `claude-work` ended up with its upstream set to `origin/main`. `git worktree add -b <branch> origin/main` auto-tracks the start point (git's `branch.autoSetupMerge` default), which has been the behavior since claude-work was introduced. With `push.default = simple` that makes `git push` refuse to push, and `git pull` tries to merge main back into the branch. Worse, `git-promote` only fills in tracking config when it's empty, so promoting one of these branches pushed it but silently left the wrong upstream in place. The `lmstudio` branch from the LM Studio session was the smoking gun: reflog says "Created from origin/main", config said `merge = refs/heads/main`.

## Approach

Add `--no-track` to the `git worktree add` call. The branch still starts from `origin/main` but with no upstream, which is the state `git-promote` (or `git push -u`) expects — tracking gets set to `origin/<branch>` on first push. `claude-review` was already correct: its branch path tracks `origin/<branch>` and `gh pr checkout` sets tracking itself.

## Reviewer notes

The two scripts now share an invariant: a branch either tracks `origin/<its-own-name>` or nothing — never `origin/main`. The asymmetry (review branches track immediately, work branches track on first push) is intentional, since it mirrors whether the remote branch exists yet.

## Testing plan

Created a throwaway worktree with the new command and confirmed no `branch.<name>.*` config gets written. Also cleared the stale upstream on the existing `lmstudio` branch with `git branch --unset-upstream`.

https://claude.ai/code/session_01YYa5t4KDYDh9tpV24zVnXb
